### PR TITLE
Basic login with developer access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,20 @@ Now that everything is set up, we can start **Quickstatements**. We have 2 ways 
 ```
 
 Now **Quickstatements** is available at http://localhost:8765/
+
+### OAuth
+
+In order to login with a developer access token, you need to register for yourself an owner-only consumer application for OAuth2:
+
+<https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration>
+
+Follow the form and be sure to tick "This consumer is for use only by <YOUR USERNAME>".
+
+The grants we probably need are
+
+* Perform high volume activity
+  * High-volume (bot) access
+* Interact with pages
+  * Edit existing pages
+  * Edit protected pages (risk rating: vandalism)
+  * Create, edit, and move pages

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Django==5.0.6
 uwsgi==2.0.26
+requests==2.32.3
 

--- a/src/qsts3/settings.py
+++ b/src/qsts3/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'web',
 ]
 
 MIDDLEWARE = [

--- a/src/qsts3/urls.py
+++ b/src/qsts3/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('web.urls')),
 ]

--- a/src/qsts3/urls.py
+++ b/src/qsts3/urls.py
@@ -14,10 +14,18 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
+from django.shortcuts import redirect
 from django.urls import include, path
 
+
+def redirect_to_login(request):
+    return redirect("/auth/login/")
+
+
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('', include('web.urls')),
+    path("admin/", admin.site.urls),
+    path("", redirect_to_login),
+    path("", include("web.urls")),
 ]

--- a/src/web/templates/layout.html
+++ b/src/web/templates/layout.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Quick Statements 3.0</title>
+</head>
+
+<body>
+  {% block content %}
+  {% endblock content %}
+</body>
+
+</html>

--- a/src/web/templates/login.html
+++ b/src/web/templates/login.html
@@ -3,5 +3,8 @@
 {% block content %}
 
 <p>Hello, world!</p>
+<!-- TODO: implement proper OAuth2 login, but for that we need to register the app -->
+
+<p><a href="{% url 'login_dev' %}"> Click here to login with a develpoment consumer key </a></p>
 
 {% endblock content %}

--- a/src/web/templates/login.html
+++ b/src/web/templates/login.html
@@ -1,0 +1,7 @@
+{% extends "layout.html" %}
+
+{% block content %}
+
+<p>Hello, world!</p>
+
+{% endblock content %}

--- a/src/web/templates/login_dev.html
+++ b/src/web/templates/login_dev.html
@@ -1,0 +1,16 @@
+{% extends "layout.html" %}
+
+{% block content %}
+
+<p> Submit your access token below. </p>
+
+<form method="POST">
+  {% csrf_token %}
+  <fieldset>
+    <label for="access_token">Access Token</label>
+    <input name="access_token" placeholder="Access Token">
+    <button>Log in</button>
+  </fieldset>
+</form>
+
+{% endblock content %}

--- a/src/web/templates/login_dev.html
+++ b/src/web/templates/login_dev.html
@@ -10,6 +10,9 @@
     <label for="access_token">Access Token</label>
     <input name="access_token" placeholder="Access Token">
     <button>Log in</button>
+    {% if error %}
+    <p style="color: red;"><small>Your access token is not valid: {{ error }}</small></p>
+    {% endif %}
   </fieldset>
 </form>
 

--- a/src/web/templates/profile.html
+++ b/src/web/templates/profile.html
@@ -2,8 +2,17 @@
 
 {% block content %}
 
-<p>Your user information should go here.</p>
-<!-- TODO: obviously let's not show this when in production... -->
-<p>This is your access token: {{ access_token }}</p>
+{% if username %}
+
+<h1> {{ username }} </h1>
+<p> You're successfully logged in! </p>
+<p><a href="{% url 'logout' %}"> Click here to log out.</a></p>
+
+{% else %}
+
+<h1> You're not logged in. </h1>
+<p><a href="{% url 'login' %}"> Click here to log in.</a></p>
+
+{% endif %}
 
 {% endblock content %}

--- a/src/web/templates/profile.html
+++ b/src/web/templates/profile.html
@@ -1,0 +1,9 @@
+{% extends "layout.html" %}
+
+{% block content %}
+
+<p>Your user information should go here.</p>
+<!-- TODO: obviously let's not show this when in production... -->
+<p>This is your access token: {{ access_token }}</p>
+
+{% endblock content %}

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from .views import (
+    login,
+)
+
+urlpatterns = [
+    path("auth/login/", login),
+]

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -2,12 +2,14 @@ from django.urls import path
 
 from .views import (
     login,
+    logout,
     login_dev,
     profile,
 )
 
 urlpatterns = [
     path("auth/login/", login, name="login"),
+    path("auth/logout/", logout, name="logout"),
     path("auth/login/dev/", login_dev, name="login_dev"),
     path("auth/profile/", profile, name="profile"),
 ]

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -2,8 +2,12 @@ from django.urls import path
 
 from .views import (
     login,
+    login_dev,
+    profile,
 )
 
 urlpatterns = [
-    path("auth/login/", login),
+    path("auth/login/", login, name="login"),
+    path("auth/login/dev/", login_dev, name="login_dev"),
+    path("auth/profile/", profile, name="profile"),
 ]

--- a/src/web/views.py
+++ b/src/web/views.py
@@ -1,7 +1,25 @@
-from django.shortcuts import render
-
-# Create your views here.
+from django.shortcuts import render, redirect
 
 
 def login(request):
     return render(request, "login.html", {})
+
+
+def login_dev(request):
+    if request.method == "POST":
+        # obtain dev token
+        token = request.POST["access_token"]
+
+        # save access token in the user's session
+        request.session["access_token"] = token
+
+        return redirect("/auth/profile/")
+    else:
+        return render(request, "login_dev.html", {})
+
+
+def profile(request):
+    data = {
+        "access_token": request.session.get("access_token"),
+    }
+    return render(request, "profile.html", data)

--- a/src/web/views.py
+++ b/src/web/views.py
@@ -1,3 +1,7 @@
 from django.shortcuts import render
 
 # Create your views here.
+
+
+def login(request):
+    return render(request, "login.html", {})

--- a/src/web/views.py
+++ b/src/web/views.py
@@ -1,8 +1,15 @@
+import requests
+
 from django.shortcuts import render, redirect
 
 
 def login(request):
     return render(request, "login.html", {})
+
+
+def logout(request):
+    request.session.flush()
+    return redirect("/")
 
 
 def login_dev(request):
@@ -19,7 +26,22 @@ def login_dev(request):
 
 
 def profile(request):
+    # TODO: move this logic into the api app
+    access_token = request.session.get("access_token")
+    if access_token is not None:
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        }
+        response = requests.get(
+            "https://www.mediawiki.org/w/rest.php/oauth2/resource/profile",
+            headers=headers,
+        )
+        username = response.json()["username"]
+    else:
+        username = None
+
     data = {
-        "access_token": request.session.get("access_token"),
+        "username": username,
     }
     return render(request, "profile.html", data)


### PR DESCRIPTION
Basic login implemented with developer access token. To obtain one, you need to follow the steps in the README.

The login verifies the access token by connecting to the Wikimedia REST API (but we should move that logic into the `api` app!) and saving the access token and the username in the user's session.

I don't know if it's a good idea to create an user in the database, I don't think we need to do that and it saves a lot of overhead! I think other WMB apps also don't save users and just save the information in a session.