### PR TITLE
fix: csv aliases should be a list of alias, like in v1

### DIFF
--- a/src/core/parsers/csv.py
+++ b/src/core/parsers/csv.py
@@ -127,6 +127,10 @@ class CSVCommandParser(BaseParser):
                             current_command["site"] = lang
                         else:
                             current_command["language"] = lang
+                        # Code expects aliases to be a list of alias, like in v1
+                        if current_command["what"] == "alias":
+                            current_command["value"]["type"] = "aliases"
+                            current_command["value"]["value"] = [current_command["value"]["value"]]
 
                     commands.append(current_command)
 

--- a/src/core/parsers/v1.py
+++ b/src/core/parsers/v1.py
@@ -96,14 +96,14 @@ class V1CommandParser(BaseParser):
         vvalue = self.parse_value(elements[2])
 
         if llen >= 3 and elements[1][0] == "A":
-            labels = []
+            aliases = []
             lang = elements[1][1:]
             for el in elements[2:]:
-                vlabel = self.parse_value(el.strip())
-                if not vlabel or vlabel["type"] != "string":
+                valias = self.parse_value(el.strip())
+                if not valias or valias["type"] != "string":
                     raise ParserException("alias must be a string instance")
-                labels.append(vlabel["value"])
-            data = {"action": "add", "what": "alias", "language": lang, "item": entity, "value": {"type": "labels", "value": labels}}
+                aliases.append(valias["value"])
+            data = {"action": "add", "what": "alias", "language": lang, "item": entity, "value": {"type": "aliases", "value": aliases}}
 
         elif llen == 3 and elements[1][0] in ["L", "D", "S"]:
             # We are adding / removing a LABEL, ALIAS, DESCRIPTION or SITELINK to our property

--- a/src/core/tests/test_batch.py
+++ b/src/core/tests/test_batch.py
@@ -505,7 +505,7 @@ Q411518,"Patterns, Predictors, and Outcome and Questions"
             {
                 "action": "add",
                 "item": "Q411518",
-                "value": {"type": "string", "value": "Sandbox 3"},
+                "value": {"type": "aliases", "value": ["Sandbox 3"]},
                 "what": "alias",
                 "language": "pt",
             },
@@ -516,7 +516,7 @@ Q411518,"Patterns, Predictors, and Outcome and Questions"
             {
                 "action": "add",
                 "item": "Q411518",
-                "value": {"type": "string", "value": "Patterns, Predictors, and Outcome and Questions"},
+                "value": {"type": "aliases", "value": ["Patterns, Predictors, and Outcome and Questions"]},
                 "what": "alias",
                 "language": "pt",
             },
@@ -608,7 +608,7 @@ Q4115189,Douglas Adams,author,Douglas Noël Adams,Q5,Q36180,Q6581097,Q463035,\"\
             {
                 "action": "add",
                 "item": "Q4115189",
-                "value": {"type": "string", "value": "Douglas Noël Adams"},
+                "value": {"type": "aliases", "value": ["Douglas Noël Adams"]},
                 "what": "alias",
                 "language": "en",
             },

--- a/src/core/tests/test_csv_parser.py
+++ b/src/core/tests/test_csv_parser.py
@@ -556,7 +556,7 @@ class TestCSVParser(TestCase):
                 {
                     "action": "add",
                     "item": "Q4115189",
-                    "value": {"type": "string", "value": "Chacara Santo Antonio"},
+                    "value": {"type": "aliases", "value": ["Chacara Santo Antonio"]},
                     "what": "alias",
                     "language": "pt",
                 },

--- a/src/core/tests/test_v1_parser.py
+++ b/src/core/tests/test_v1_parser.py
@@ -215,7 +215,7 @@ class TestV1ParserCommand(TestCase):
                 "what": "alias",
                 "item": "Q1234",
                 "language": "pt",
-                "value": {"type": "labels", "value": ["Texto brasileiro"]},
+                "value": {"type": "aliases", "value": ["Texto brasileiro"]},
             },
         )
 


### PR DESCRIPTION
this means we could also add the functionality of multiple aliases, which I don't know if it's possible today in current qs

also, this was failing with csv commands because the BatchCommand model was expecting a list of strings