### PR TITLE
 Add Docker Compose Deployment with MariaDB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   DJANGO_SECRET_KEY: dummysecretkey123
   OAUTH_CLIENT_ID: dummyoauthclientid
   OAUTH_CLIENT_SECRET: dummyoauthclientsecret
+  DB_ENGINE: django.db.backends.sqlite3
 
 jobs:
   build:

--- a/bin/cmd_run.sh
+++ b/bin/cmd_run.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+
+echo "Giving ${DB_USER} all privileges on test_${DB_NAME} database"
+sudo apt install mariadb-client -y
+mariadb --host="${DB_HOST}" --database="${DB_NAME}" --user=root -p"${DB_ROOT_PASSWORD}" --execute="GRANT all privileges ON test_${DB_NAME}.* TO '${DB_USER}'@'%';"
+sudo apt purge mariadb-client -y
+
 sudo service nginx start
 cd /home/wmb/www/src && python3 manage.py collectstatic --no-input && chmod -R 777 /home/wmb/www/src/static
 cd /home/wmb/www/src && python3 manage.py migrate --no-input

--- a/bin/cmd_run.sh
+++ b/bin/cmd_run.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
 
-echo "Giving ${DB_USER} all privileges on test_${DB_NAME} database"
-sudo apt install mariadb-client -y
-mariadb --host="${DB_HOST}" --database="${DB_NAME}" --user=root -p"${DB_ROOT_PASSWORD}" --execute="GRANT all privileges ON test_${DB_NAME}.* TO '${DB_USER}'@'%';"
-sudo apt purge mariadb-client -y
-
 sudo service nginx start
 cd /home/wmb/www/src && python3 manage.py collectstatic --no-input && chmod -R 777 /home/wmb/www/src/static
 cd /home/wmb/www/src && python3 manage.py migrate --no-input

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,21 +2,21 @@
 
 set -eu
 
-cd ~/www/python || exit
+# cd ~/www/python || exit
 
-echo "==> Updating git repository..."
-git pull
+# echo "==> Updating git repository..."
+# git pull
 
-echo "==> Entering python shell..."
-toolforge webservice --backend=kubernetes python3.11 shell -- \
-  webservice-python-bootstrap && \
-  source venv/bin/activate && \
-  echo "==> Installing dependencies..." && \
-  pip install -r requirements.txt && \
-  echo "==> Running migrations..." && \
-  python3 src/manage.py migrate && \
-  echo "==> Collecting static files..." && \
-  python3 src/manage.py collectstatic --noinput
+# echo "==> Entering python shell..."
+# toolforge webservice --backend=kubernetes python3.11 shell -- \
+#   webservice-python-bootstrap && \
+#   source venv/bin/activate && \
+#   echo "==> Installing dependencies..." && \
+#   pip install -r requirements.txt && \
+#   echo "==> Running migrations..." && \
+#   python3 src/manage.py migrate && \
+#   echo "==> Collecting static files..." && \
+#   python3 src/manage.py collectstatic --noinput
 
-echo "==> Restarting webservice..."
-toolforge webservice --backend=kubernetes python3.11 restart
+# echo "==> Restarting webservice..."
+# toolforge webservice --backend=kubernetes python3.11 restart

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  mariadb:
+    image: mariadb
+    container_name: mariadb
+    environment:
+      MYSQL_ROOT_PASSWORD: your_root_password
+      MYSQL_DATABASE: your_database_name
+      MYSQL_USER: your_user
+      MYSQL_PASSWORD: your_user_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mariadb_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    restart: always
+    
+
+  quickstatements:
+    build:
+      context: ./
+      dockerfile: Dockerfile
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    env_file:
+      - ./etc/env
+    ports:
+      - "8765:80"
+      - "8000:8000"
+    volumes:
+      - ./src:/home/wmb/www/src
+    command: /home/wmb/www/cmd_run.sh
+    restart: always
+
+volumes:
+  mariadb_data:
+  src:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,14 +3,12 @@ version: '3.8'
 services:
   mariadb:
     image: mariadb
-    container_name: mariadb
+    container_name: "${DB_HOST}"
     environment:
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
-      MYSQL_DATABASE: "${DB_NAME}"
-      MYSQL_USER: "${DB_USER}"
-      MYSQL_PASSWORD: "${DB_PASSWORD}"
-    ports:
-      - "${DB_PORT}:${DB_PORT}"
+      MYSQL_DATABASE: "${DB_NAME}"      
+    expose:
+      - "3306"
     volumes:
       - mariadb_data:/var/lib/mysql
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     image: mariadb
     container_name: mariadb
     environment:
-      MYSQL_ROOT_PASSWORD: your_root_password
-      MYSQL_DATABASE: your_database_name
-      MYSQL_USER: your_user
-      MYSQL_PASSWORD: your_user_password
+      MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASSWORD}"
+      MYSQL_DATABASE: "${DB_NAME}"
+      MYSQL_USER: "${DB_USER}"
+      MYSQL_PASSWORD: "${DB_PASSWORD}"
     ports:
-      - "3306:3306"
+      - "${DB_PORT}:${DB_PORT}"
     volumes:
       - mariadb_data:/var/lib/mysql
     healthcheck:
@@ -20,7 +20,7 @@ services:
       timeout: 5s
       retries: 3
     restart: always
-    
+
 
   quickstatements:
     build:
@@ -41,4 +41,3 @@ services:
 
 volumes:
   mariadb_data:
-  src:

--- a/etc/env.SAMPLE
+++ b/etc/env.SAMPLE
@@ -7,13 +7,12 @@ BASE_REST_URL=<optional>
 # example: https://test.wikidata.org/w/rest.php
 # defaults to: https://www.wikidata.org/w/rest.php
 
-
-DB_ROOT_PASSWORD=your_db_root_password
+DB_ROOT_PASSWORD=db_root_password
 DB_ENGINE=django.db.backends.mysql
-DB_NAME=your_db_name
-DB_USER=your_db_user
-DB_PASSWORD=your_db_password
-DB_HOST=mariadb
+DB_NAME=db_name
+DB_USER=root
+DB_PASSWORD=db_root_password
+DB_HOST=maria_db
 DB_PORT=3306
 
 TOOLFORGE_TOOL_NAME=

--- a/etc/env.SAMPLE
+++ b/etc/env.SAMPLE
@@ -7,5 +7,7 @@ BASE_REST_URL=<optional>
 # example: https://test.wikidata.org/w/rest.php
 # defaults to: https://www.wikidata.org/w/rest.php
 
+MARIADB_READ_DEFAULT_FILE=/home/wmb/www/src/qsdev.cnf
+
 TOOLFORGE_TOOL_NAME=
 # only use when deploying to Toolforgre

--- a/etc/env.SAMPLE
+++ b/etc/env.SAMPLE
@@ -7,7 +7,14 @@ BASE_REST_URL=<optional>
 # example: https://test.wikidata.org/w/rest.php
 # defaults to: https://www.wikidata.org/w/rest.php
 
-MARIADB_READ_DEFAULT_FILE=/home/wmb/www/src/qsdev.cnf
+
+DB_ROOT_PASSWORD=your_db_root_password
+DB_ENGINE=django.db.backends.mysql
+DB_NAME=your_db_name
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_HOST=mariadb
+DB_PORT=3306
 
 TOOLFORGE_TOOL_NAME=
 # only use when deploying to Toolforgre

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ djangorestframework==3.15.2
 markdown==3.7      # Markdown support for the browsable API.
 django-filter==24.3  #
 jsonpatch==1.33
-
+mysqlclient>=2.0.0

--- a/src/qsdev.cnf
+++ b/src/qsdev.cnf
@@ -1,0 +1,7 @@
+[client]
+host = mariadb
+port = 3306
+database = your_database_name
+user = your_user
+password = your_user_password
+default-character-set = utf8

--- a/src/qsts3/settings.py
+++ b/src/qsts3/settings.py
@@ -27,7 +27,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ["qs-dev.toolforge.org", "localhost"]
 

--- a/src/qsts3/settings.py
+++ b/src/qsts3/settings.py
@@ -83,25 +83,17 @@ WSGI_APPLICATION = "qsts3.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
+# MariaDB setup
 DATABASES = {
-   "default": {
-       "ENGINE": "django.db.backends.sqlite3",
-       "NAME": BASE_DIR / "db.sqlite3",
-   }
+    "default": {
+        "ENGINE": os.getenv("DB_ENGINE", "django.db.backends.mysql"),
+        "NAME": os.getenv("DB_NAME", "your_db_name"),
+        "USER": os.getenv("DB_USER", "your_db_user"),
+        "PASSWORD": os.getenv("DB_PASSWORD", "your_db_password"),
+        "HOST": os.getenv("DB_HOST", "mariadb"),
+        "PORT": os.getenv("DB_PORT", 3306),
+    },
 }
-
-read_default_file = os.getenv("MARIADB_READ_DEFAULT_FILE")
-
-if read_default_file:
-    # MariaDB setup
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.db.backends.mysql",
-            "OPTIONS": {
-                "read_default_file": read_default_file,
-            },
-        }
-    }
 
 
 # Password validation

--- a/src/qsts3/settings.py
+++ b/src/qsts3/settings.py
@@ -84,11 +84,24 @@ WSGI_APPLICATION = "qsts3.wsgi.application"
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases
 
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
-    }
+   "default": {
+       "ENGINE": "django.db.backends.sqlite3",
+       "NAME": BASE_DIR / "db.sqlite3",
+   }
 }
+
+read_default_file = os.getenv("MARIADB_READ_DEFAULT_FILE")
+
+if read_default_file:
+    # MariaDB setup
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.mysql",
+            "OPTIONS": {
+                "read_default_file": read_default_file,
+            },
+        }
+    }
 
 
 # Password validation

--- a/src/web/tests/test_views.py
+++ b/src/web/tests/test_views.py
@@ -594,7 +594,7 @@ class ViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("batch.html")
         self.assertNotInRes(f"""<form method="GET" action="/batch/{pk}/report/">""", response)
-        self.assertNotInRes(f"""<input type="submit" value="Download report">""", response)
+        self.assertNotInRes("""<input type="submit" value="Download report">""", response)
 
         batch.run()
 
@@ -602,7 +602,7 @@ class ViewsTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("batch.html")
         self.assertInRes(f"""<form method="GET" action="/batch/{pk}/report/">""", response)
-        self.assertInRes(f"""<input type="submit" value="Download report">""", response)
+        self.assertInRes("""<input type="submit" value="Download report">""", response)
 
         response = self.client.post(f"/batch/{pk}/report/")
         self.assertEqual(response.status_code, 405)
@@ -612,8 +612,8 @@ class ViewsTest(TestCase):
         self.assertEqual(response.headers["Content-Disposition"], f'attachment; filename="batch-{pk}-report.csv"')
         result = (
             """b'batch_id,index,operation,status,error,message,entity_id,raw_input\\r\\n"""
-            """1,0,set_statement,Done,,,Q1234,Q1234|P2|Q1\\r\\n"""
-            """1,1,set_label,Done,,,Q11,"Q11|Len|""label""\"\\r\\n\'"""
+            f"""{pk},0,set_statement,Done,,,Q1234,Q1234|P2|Q1\\r\\n"""
+            f"""{pk},1,set_label,Done,,,Q11,"Q11|Len|""label""\"\\r\\n\'"""
         )
         self.assertEqual(result, str(response.content).strip())
 


### PR DESCRIPTION
# Summary:
This PR adds a Docker Compose configuration to set up a MariaDB instance, replicating the Toolforge infrastructure for local development.

# Changes:

 - Introduced docker-compose.yml for easy deployment.
 - Configured MariaDB service to match production settings.

## ToDo: 
 - Make sure that tests are working perfectly
 - Add sql commands to MariaDB entrypoint so that test databases can be automatically created
 - Documentation of deployment (probably replacing Makefile)
 - Update CI accordingly