### PR TITLE
Reformat with black/pyisort

### DIFF
--- a/src/api/admin.py
+++ b/src/api/admin.py
@@ -1,2 +1,1 @@
-
 # Register your models here.

--- a/src/api/apps.py
+++ b/src/api/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class ApiConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'api'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "api"

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -1,2 +1,1 @@
-
 # Create your models here.

--- a/src/api/paginators.py
+++ b/src/api/paginators.py
@@ -1,5 +1,3 @@
-
-
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 from rest_framework.reverse import reverse_lazy
@@ -12,7 +10,10 @@ class CustomPagination(PageNumberPagination):
     def get_paginated_response(self, data):
         return Response(
             {
-                "links": {"next": self.get_next_link(), "previous": self.get_previous_link()},
+                "links": {
+                    "next": self.get_next_link(),
+                    "previous": self.get_previous_link(),
+                },
                 "filters": self.request.query_params,
                 "total": self.page.paginator.count,
                 "page_size": len(self.page.object_list),
@@ -26,15 +27,20 @@ class CustomBatchCommandPagination(PageNumberPagination):
     max_page_size = 100
 
     def get_paginated_response(self, data):
-        batch = self.request.batch # We injected batch reference in the view
+        batch = self.request.batch  # We injected batch reference in the view
         return Response(
             {
-                "links": {"next": self.get_next_link(), "previous": self.get_previous_link()},
+                "links": {
+                    "next": self.get_next_link(),
+                    "previous": self.get_previous_link(),
+                },
                 "total": self.page.paginator.count,
                 "page_size": len(self.page.object_list),
                 "batch": {
                     "pk": batch.pk,
-                    "url": reverse_lazy("batch-detail", kwargs={"pk": batch.pk}, request=self.request)
+                    "url": reverse_lazy(
+                        "batch-detail", kwargs={"pk": batch.pk}, request=self.request
+                    ),
                 },
                 "commands": data,
             }

--- a/src/api/serializers.py
+++ b/src/api/serializers.py
@@ -1,4 +1,3 @@
-
 from rest_framework import serializers
 from rest_framework.reverse import reverse_lazy
 
@@ -18,7 +17,16 @@ class BatchListSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Batch
-        fields = ["url", "pk", "user", "name", "status", "message", "created", "modified"]
+        fields = [
+            "url",
+            "pk",
+            "user",
+            "name",
+            "status",
+            "message",
+            "created",
+            "modified",
+        ]
 
 
 class BatchDetailSerializer(serializers.HyperlinkedModelSerializer):
@@ -34,7 +42,9 @@ class BatchDetailSerializer(serializers.HyperlinkedModelSerializer):
         return {"code": obj.status, "display": obj.get_status_display()}
 
     def get_commands_url(self, obj):
-        return reverse_lazy("command-list", kwargs={"batchpk": obj.pk}, request=self.context["request"])
+        return reverse_lazy(
+            "command-list", kwargs={"batchpk": obj.pk}, request=self.context["request"]
+        )
 
     def get_summary(self, obj):
         return {
@@ -42,12 +52,22 @@ class BatchDetailSerializer(serializers.HyperlinkedModelSerializer):
             "running_commands": obj.running_commands,
             "done_commands": obj.done_commands,
             "error_commands": obj.error_commands,
-            "total_commands": obj.total_commands
+            "total_commands": obj.total_commands,
         }
 
     class Meta:
         model = Batch
-        fields = ["pk", "name", "user", "status", "summary", "commands_url","message", "created", "modified"]
+        fields = [
+            "pk",
+            "name",
+            "user",
+            "status",
+            "summary",
+            "commands_url",
+            "message",
+            "created",
+            "modified",
+        ]
 
 
 class BatchCommandListSerializer(serializers.HyperlinkedModelSerializer):
@@ -62,11 +82,23 @@ class BatchCommandListSerializer(serializers.HyperlinkedModelSerializer):
         return obj.get_action_display()
 
     def get_url(self, obj):
-        return reverse_lazy("command-detail", kwargs={"pk": obj.pk}, request=self.context["request"])
+        return reverse_lazy(
+            "command-detail", kwargs={"pk": obj.pk}, request=self.context["request"]
+        )
 
     class Meta:
         model = BatchCommand
-        fields = ["url", "pk", "index", "action", "json", "response_json",  "status", "created", "modified"]
+        fields = [
+            "url",
+            "pk",
+            "index",
+            "action",
+            "json",
+            "response_json",
+            "status",
+            "created",
+            "modified",
+        ]
 
 
 class BatchCommandDetailSerializer(serializers.HyperlinkedModelSerializer):
@@ -86,5 +118,15 @@ class BatchCommandDetailSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = BatchCommand
-        fields = ["batch", "pk", "index", "action", "raw", "json", "response_json", "status", "created", "modified"]
-
+        fields = [
+            "batch",
+            "pk",
+            "index",
+            "action",
+            "raw",
+            "json",
+            "response_json",
+            "status",
+            "created",
+            "modified",
+        ]

--- a/src/api/tests/test_batch_command_detail_view.py
+++ b/src/api/tests/test_batch_command_detail_view.py
@@ -1,4 +1,3 @@
-
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -11,7 +10,7 @@ from core.models import BatchCommand
 
 
 class BatchCommandDetailViewTest(TestCase):
-    
+
     def setUp(self):
         self.user = User.objects.create(username="myuser")
         self.token = Token.objects.create(user=self.user)
@@ -22,108 +21,132 @@ class BatchCommandDetailViewTest(TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_bad_auth_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token fdsfsdfsfsdafsdfsdfsfsdfsad')
+        self.client.credentials(HTTP_AUTHORIZATION="Token fdsfsdfsfsdafsdfsdfsfsdfsad")
         response = self.client.get(reverse("command-detail", kwargs={"pk": 1}))
         self.assertEqual(response.status_code, 401)
 
     def test_non_existing_authenticated_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("command-detail", kwargs={"pk": 1}))
         self.assertEqual(response.status_code, 404)
 
     def test_batch_command_authenticated_request(self):
-        batch = Batch.objects.create(name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING)
+        batch = Batch.objects.create(
+            name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING
+        )
         command = BatchCommand.objects.create(
-            batch=batch, index=1, action=BatchCommand.ACTION_ADD, json={}, status=BatchCommand.STATUS_INITIAL
+            batch=batch,
+            index=1,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            status=BatchCommand.STATUS_INITIAL,
         )
 
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
 
         response = self.client.get(reverse("command-detail", kwargs={"pk": command.pk}))
-        self.assertEqual(response.status_code, 200)  
+        self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertEqual(data['pk'], command.pk)
-        self.assertEqual(data['batch']['pk'], batch.pk)
-        self.assertEqual(data['batch']['user'], 'testuser')
-        self.assertEqual(data['batch']['name'], 'Batch 1')
-        self.assertEqual(data['batch']['url'], f'http://testserver/api/v1/batches/{batch.pk}/')
-        self.assertEqual(data['batch']['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(data['index'], 1)
-        self.assertEqual(data['action'], 'ADD')
-        self.assertEqual(data['raw'], '')
-        self.assertEqual(data['json'], {})
-        self.assertEqual(data['response_json'], {})
-        self.assertEqual(data['status'], {'code': 0, 'display': 'Initial'})
+        self.assertEqual(data["pk"], command.pk)
+        self.assertEqual(data["batch"]["pk"], batch.pk)
+        self.assertEqual(data["batch"]["user"], "testuser")
+        self.assertEqual(data["batch"]["name"], "Batch 1")
+        self.assertEqual(
+            data["batch"]["url"], f"http://testserver/api/v1/batches/{batch.pk}/"
+        )
+        self.assertEqual(data["batch"]["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(data["index"], 1)
+        self.assertEqual(data["action"], "ADD")
+        self.assertEqual(data["raw"], "")
+        self.assertEqual(data["json"], {})
+        self.assertEqual(data["response_json"], {})
+        self.assertEqual(data["status"], {"code": 0, "display": "Initial"})
 
         command.status = BatchCommand.STATUS_RUNNING
-        command.raw = 'CREATE'
+        command.raw = "CREATE"
         command.json = {"action": "create", "type": "item"}
         command.save()
 
         response = self.client.get(reverse("command-detail", kwargs={"pk": command.pk}))
-        self.assertEqual(response.status_code, 200)  
+        self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertEqual(data['pk'], command.pk)
-        self.assertEqual(data['batch']['pk'], batch.pk)
-        self.assertEqual(data['batch']['user'], 'testuser')
-        self.assertEqual(data['batch']['name'], 'Batch 1')
-        self.assertEqual(data['batch']['url'], f'http://testserver/api/v1/batches/{batch.pk}/')
-        self.assertEqual(data['batch']['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(data['index'], 1)
-        self.assertEqual(data['action'], 'ADD')
-        self.assertEqual(data['raw'], 'CREATE')
-        self.assertEqual(data['json'], {"action": "create", "type": "item"})
-        self.assertEqual(data['response_json'], {})
-        self.assertEqual(data['status'], {'code': 1, 'display': 'Running'})
+        self.assertEqual(data["pk"], command.pk)
+        self.assertEqual(data["batch"]["pk"], batch.pk)
+        self.assertEqual(data["batch"]["user"], "testuser")
+        self.assertEqual(data["batch"]["name"], "Batch 1")
+        self.assertEqual(
+            data["batch"]["url"], f"http://testserver/api/v1/batches/{batch.pk}/"
+        )
+        self.assertEqual(data["batch"]["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(data["index"], 1)
+        self.assertEqual(data["action"], "ADD")
+        self.assertEqual(data["raw"], "CREATE")
+        self.assertEqual(data["json"], {"action": "create", "type": "item"})
+        self.assertEqual(data["response_json"], {})
+        self.assertEqual(data["status"], {"code": 1, "display": "Running"})
 
         command.status = BatchCommand.STATUS_DONE
         command.action = BatchCommand.ACTION_CREATE
         command.save()
 
         response = self.client.get(reverse("command-detail", kwargs={"pk": command.pk}))
-        self.assertEqual(response.status_code, 200)  
+        self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertEqual(data['pk'], command.pk)
-        self.assertEqual(data['batch']['pk'], batch.pk)
-        self.assertEqual(data['batch']['user'], 'testuser')
-        self.assertEqual(data['batch']['name'], 'Batch 1')
-        self.assertEqual(data['batch']['url'], f'http://testserver/api/v1/batches/{batch.pk}/')
-        self.assertEqual(data['batch']['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(data['index'], 1)
-        self.assertEqual(data['action'], 'CREATE')
-        self.assertEqual(data['raw'], 'CREATE')
-        self.assertEqual(data['json'], {"action": "create", "type": "item"})
-        self.assertEqual(data['response_json'], {})
-        self.assertEqual(data['status'], {'code': 2, 'display': 'Done'})
+        self.assertEqual(data["pk"], command.pk)
+        self.assertEqual(data["batch"]["pk"], batch.pk)
+        self.assertEqual(data["batch"]["user"], "testuser")
+        self.assertEqual(data["batch"]["name"], "Batch 1")
+        self.assertEqual(
+            data["batch"]["url"], f"http://testserver/api/v1/batches/{batch.pk}/"
+        )
+        self.assertEqual(data["batch"]["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(data["index"], 1)
+        self.assertEqual(data["action"], "CREATE")
+        self.assertEqual(data["raw"], "CREATE")
+        self.assertEqual(data["json"], {"action": "create", "type": "item"})
+        self.assertEqual(data["response_json"], {})
+        self.assertEqual(data["status"], {"code": 2, "display": "Done"})
 
         command.status = BatchCommand.STATUS_ERROR
         command.save()
 
         response = self.client.get(reverse("command-detail", kwargs={"pk": command.pk}))
-        self.assertEqual(response.status_code, 200)  
+        self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertEqual(data['pk'], command.pk)
-        self.assertEqual(data['batch']['pk'], batch.pk)
-        self.assertEqual(data['batch']['user'], 'testuser')
-        self.assertEqual(data['batch']['name'], 'Batch 1')
-        self.assertEqual(data['batch']['url'], f'http://testserver/api/v1/batches/{batch.pk}/')
-        self.assertEqual(data['batch']['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(data['index'], 1)
-        self.assertEqual(data['action'], 'CREATE')
-        self.assertEqual(data['raw'], 'CREATE')
-        self.assertEqual(data['json'], {"action": "create", "type": "item"})
-        self.assertEqual(data['response_json'], {})
-        self.assertEqual(data['status'], {'code': -1, 'display': 'Error'})
+        self.assertEqual(data["pk"], command.pk)
+        self.assertEqual(data["batch"]["pk"], batch.pk)
+        self.assertEqual(data["batch"]["user"], "testuser")
+        self.assertEqual(data["batch"]["name"], "Batch 1")
+        self.assertEqual(
+            data["batch"]["url"], f"http://testserver/api/v1/batches/{batch.pk}/"
+        )
+        self.assertEqual(data["batch"]["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(data["index"], 1)
+        self.assertEqual(data["action"], "CREATE")
+        self.assertEqual(data["raw"], "CREATE")
+        self.assertEqual(data["json"], {"action": "create", "type": "item"})
+        self.assertEqual(data["response_json"], {})
+        self.assertEqual(data["status"], {"code": -1, "display": "Error"})
 
     def test_non_allowed_methods_request(self):
-        original = Batch.objects.create(name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING)
-        command = BatchCommand.objects.create(
-            batch=original, index=1, action=BatchCommand.ACTION_ADD, json={}, status=BatchCommand.STATUS_INITIAL
+        original = Batch.objects.create(
+            name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING
         )
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
-        response = self.client.post(reverse("command-detail", kwargs={"pk": command.pk}))
+        command = BatchCommand.objects.create(
+            batch=original,
+            index=1,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            status=BatchCommand.STATUS_INITIAL,
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+        response = self.client.post(
+            reverse("command-detail", kwargs={"pk": command.pk})
+        )
         self.assertEqual(response.status_code, 405)
         response = self.client.put(reverse("command-detail", kwargs={"pk": command.pk}))
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(reverse("command-detail", kwargs={"pk": command.pk}))
+        response = self.client.delete(
+            reverse("command-detail", kwargs={"pk": command.pk})
+        )
         self.assertEqual(response.status_code, 405)

--- a/src/api/tests/test_batch_command_list_view.py
+++ b/src/api/tests/test_batch_command_list_view.py
@@ -42,7 +42,9 @@ class BatchCommandDetailViewTest(TestCase):
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
 
-        response = self.client.get(reverse("command-list", kwargs={"batchpk": batch.pk}))
+        response = self.client.get(
+            reverse("command-list", kwargs={"batchpk": batch.pk})
+        )
         self.assertEqual(response.status_code, 200)
         data = response.data
 
@@ -50,7 +52,10 @@ class BatchCommandDetailViewTest(TestCase):
         self.assertEqual(data["links"]["previous"], None)
         self.assertEqual(data["total"], 3)
         self.assertEqual(data["page_size"], 3)
-        self.assertEqual(data["batch"], {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"})
+        self.assertEqual(
+            data["batch"],
+            {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"},
+        )
 
         c0 = data["commands"][0]
         self.assertEqual(c0["index"], 0)
@@ -80,34 +85,63 @@ class BatchCommandDetailViewTest(TestCase):
     def test_batch_command_list_paginated_authenticated_request(self):
         batch = Batch.objects.create(name="Paginated batch", user="user")
         for i in range(0, 250):
-            BatchCommand.objects.create(batch=batch, json={}, action=BatchCommand.ACTION_ADD, index=i)
+            BatchCommand.objects.create(
+                batch=batch, json={}, action=BatchCommand.ACTION_ADD, index=i
+            )
 
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
 
-        response = self.client.get(f"http://testserver/api/v1/batches/{batch.pk}/commands/")
+        response = self.client.get(
+            f"http://testserver/api/v1/batches/{batch.pk}/commands/"
+        )
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertEqual(data["links"]["next"], f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=2")
+        self.assertEqual(
+            data["links"]["next"],
+            f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=2",
+        )
         self.assertEqual(data["links"]["previous"], None)
         self.assertEqual(data["total"], 250)
         self.assertEqual(data["page_size"], 100)
-        self.assertEqual(data["batch"], {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"})
+        self.assertEqual(
+            data["batch"],
+            {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"},
+        )
 
-        response = self.client.get(f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=2")
+        response = self.client.get(
+            f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=2"
+        )
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertEqual(data["batch"], {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"})
-        self.assertEqual(data["links"]["next"], f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=3")
-        self.assertEqual(data["links"]["previous"], f"http://testserver/api/v1/batches/{batch.pk}/commands/")
+        self.assertEqual(
+            data["batch"],
+            {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"},
+        )
+        self.assertEqual(
+            data["links"]["next"],
+            f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=3",
+        )
+        self.assertEqual(
+            data["links"]["previous"],
+            f"http://testserver/api/v1/batches/{batch.pk}/commands/",
+        )
         self.assertEqual(data["total"], 250)
         self.assertEqual(data["page_size"], 100)
 
-        response = self.client.get(f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=3")
+        response = self.client.get(
+            f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=3"
+        )
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertEqual(data["batch"], {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"})
+        self.assertEqual(
+            data["batch"],
+            {"pk": batch.pk, "url": f"http://testserver/api/v1/batches/{batch.pk}/"},
+        )
         self.assertEqual(data["links"]["next"], None)
-        self.assertEqual(data["links"]["previous"], f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=2")
+        self.assertEqual(
+            data["links"]["previous"],
+            f"http://testserver/api/v1/batches/{batch.pk}/commands/?page=2",
+        )
         self.assertEqual(data["total"], 250)
         self.assertEqual(data["page_size"], 50)
 

--- a/src/api/tests/test_batch_detail_view.py
+++ b/src/api/tests/test_batch_detail_view.py
@@ -1,4 +1,3 @@
-
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -11,7 +10,7 @@ from core.models import BatchCommand
 
 
 class BatchDetailViewTest(TestCase):
-    
+
     def setUp(self):
         self.user = User.objects.create(username="myuser")
         self.token = Token.objects.create(user=self.user)
@@ -22,141 +21,247 @@ class BatchDetailViewTest(TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_bad_auth_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token fdsfsdfsfsdafsdfsdfsfsdfsad')
+        self.client.credentials(HTTP_AUTHORIZATION="Token fdsfsdfsfsdafsdfsdfsfsdfsad")
         response = self.client.get(reverse("batch-detail", kwargs={"pk": 1}))
         self.assertEqual(response.status_code, 401)
 
     def test_non_existing_authenticated_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("batch-detail", kwargs={"pk": 1}))
         self.assertEqual(response.status_code, 404)
 
     def test_initial_empty_batch_authenticated_request(self):
         original = Batch.objects.create(name="Batch 0", user="testuser")
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("batch-detail", kwargs={"pk": original.pk}))
         self.assertEqual(response.status_code, 200)
         batch = response.data
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 0')
-        self.assertEqual(batch['status'], {'code': 1, 'display': 'Initial'})
-        self.assertEqual(batch['summary'], {'initial_commands': 0, 'error_commands': 0, 'running_commands': 0, 'done_commands': 0, 'total_commands': 0})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
-        self.assertEqual(batch['commands_url'], f'http://testserver/api/v1/batches/{original.pk}/commands/')
-
-    def test_batch_authenticated_request(self):
-        original = Batch.objects.create(name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING)
-        command = BatchCommand.objects.create(
-            batch=original, index=1, action=BatchCommand.ACTION_ADD, json={}, status=BatchCommand.STATUS_INITIAL
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 0")
+        self.assertEqual(batch["status"], {"code": 1, "display": "Initial"})
+        self.assertEqual(
+            batch["summary"],
+            {
+                "initial_commands": 0,
+                "error_commands": 0,
+                "running_commands": 0,
+                "done_commands": 0,
+                "total_commands": 0,
+            },
+        )
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
+        self.assertEqual(
+            batch["commands_url"],
+            f"http://testserver/api/v1/batches/{original.pk}/commands/",
         )
 
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+    def test_batch_authenticated_request(self):
+        original = Batch.objects.create(
+            name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING
+        )
+        command = BatchCommand.objects.create(
+            batch=original,
+            index=1,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            status=BatchCommand.STATUS_INITIAL,
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
 
         response = self.client.get(reverse("batch-detail", kwargs={"pk": original.pk}))
-        self.assertEqual(response.status_code, 200)        
+        self.assertEqual(response.status_code, 200)
         batch = response.data
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 1')
-        self.assertEqual(batch['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(batch['summary'], {'initial_commands': 1, 'error_commands': 0, 'running_commands': 0, 'done_commands': 0, 'total_commands': 1})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
-        self.assertEqual(batch['commands_url'], f'http://testserver/api/v1/batches/{original.pk}/commands/')
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 1")
+        self.assertEqual(batch["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(
+            batch["summary"],
+            {
+                "initial_commands": 1,
+                "error_commands": 0,
+                "running_commands": 0,
+                "done_commands": 0,
+                "total_commands": 1,
+            },
+        )
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
+        self.assertEqual(
+            batch["commands_url"],
+            f"http://testserver/api/v1/batches/{original.pk}/commands/",
+        )
 
         command.status = BatchCommand.STATUS_RUNNING
         command.save()
 
         response = self.client.get(reverse("batch-detail", kwargs={"pk": original.pk}))
-        self.assertEqual(response.status_code, 200)        
+        self.assertEqual(response.status_code, 200)
         batch = response.data
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 1')
-        self.assertEqual(batch['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(batch['summary'], {'initial_commands': 0, 'error_commands': 0, 'running_commands': 1, 'done_commands': 0, 'total_commands': 1})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
-        self.assertEqual(batch['commands_url'], f'http://testserver/api/v1/batches/{original.pk}/commands/')
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 1")
+        self.assertEqual(batch["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(
+            batch["summary"],
+            {
+                "initial_commands": 0,
+                "error_commands": 0,
+                "running_commands": 1,
+                "done_commands": 0,
+                "total_commands": 1,
+            },
+        )
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
+        self.assertEqual(
+            batch["commands_url"],
+            f"http://testserver/api/v1/batches/{original.pk}/commands/",
+        )
 
         command.status = BatchCommand.STATUS_DONE
         command.save()
 
         response = self.client.get(reverse("batch-detail", kwargs={"pk": original.pk}))
-        self.assertEqual(response.status_code, 200)        
+        self.assertEqual(response.status_code, 200)
         batch = response.data
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 1')
-        self.assertEqual(batch['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(batch['summary'], {'initial_commands': 0, 'error_commands': 0, 'running_commands': 0, 'done_commands': 1, 'total_commands': 1})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
-        self.assertEqual(batch['commands_url'], f'http://testserver/api/v1/batches/{original.pk}/commands/')
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 1")
+        self.assertEqual(batch["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(
+            batch["summary"],
+            {
+                "initial_commands": 0,
+                "error_commands": 0,
+                "running_commands": 0,
+                "done_commands": 1,
+                "total_commands": 1,
+            },
+        )
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
+        self.assertEqual(
+            batch["commands_url"],
+            f"http://testserver/api/v1/batches/{original.pk}/commands/",
+        )
 
         _command2 = BatchCommand.objects.create(
-            batch=original, index=1, action=BatchCommand.ACTION_ADD, json={}, status=BatchCommand.STATUS_INITIAL
+            batch=original,
+            index=1,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            status=BatchCommand.STATUS_INITIAL,
         )
 
         response = self.client.get(reverse("batch-detail", kwargs={"pk": original.pk}))
-        self.assertEqual(response.status_code, 200)        
+        self.assertEqual(response.status_code, 200)
         batch = response.data
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 1')
-        self.assertEqual(batch['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(batch['summary'], {'initial_commands': 1, 'error_commands': 0, 'running_commands': 0, 'done_commands': 1, 'total_commands': 2})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
-        self.assertEqual(batch['commands_url'], f'http://testserver/api/v1/batches/{original.pk}/commands/')
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 1")
+        self.assertEqual(batch["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(
+            batch["summary"],
+            {
+                "initial_commands": 1,
+                "error_commands": 0,
+                "running_commands": 0,
+                "done_commands": 1,
+                "total_commands": 2,
+            },
+        )
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
+        self.assertEqual(
+            batch["commands_url"],
+            f"http://testserver/api/v1/batches/{original.pk}/commands/",
+        )
 
         _command3 = BatchCommand.objects.create(
-            batch=original, index=1, action=BatchCommand.ACTION_ADD, json={}, status=BatchCommand.STATUS_RUNNING
+            batch=original,
+            index=1,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            status=BatchCommand.STATUS_RUNNING,
         )
 
         response = self.client.get(reverse("batch-detail", kwargs={"pk": original.pk}))
-        self.assertEqual(response.status_code, 200)        
+        self.assertEqual(response.status_code, 200)
         batch = response.data
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 1')
-        self.assertEqual(batch['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(batch['summary'], {'initial_commands': 1, 'error_commands': 0, 'running_commands': 1, 'done_commands': 1, 'total_commands': 3})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
-        self.assertEqual(batch['commands_url'], f'http://testserver/api/v1/batches/{original.pk}/commands/')
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 1")
+        self.assertEqual(batch["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(
+            batch["summary"],
+            {
+                "initial_commands": 1,
+                "error_commands": 0,
+                "running_commands": 1,
+                "done_commands": 1,
+                "total_commands": 3,
+            },
+        )
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
+        self.assertEqual(
+            batch["commands_url"],
+            f"http://testserver/api/v1/batches/{original.pk}/commands/",
+        )
 
         _command4 = BatchCommand.objects.create(
-            batch=original, index=1, action=BatchCommand.ACTION_CREATE, json={}, status=BatchCommand.STATUS_ERROR
+            batch=original,
+            index=1,
+            action=BatchCommand.ACTION_CREATE,
+            json={},
+            status=BatchCommand.STATUS_ERROR,
         )
 
         response = self.client.get(reverse("batch-detail", kwargs={"pk": original.pk}))
-        self.assertEqual(response.status_code, 200)        
+        self.assertEqual(response.status_code, 200)
         batch = response.data
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 1')
-        self.assertEqual(batch['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(batch['summary'], {'initial_commands': 1, 'error_commands': 1, 'running_commands': 1, 'done_commands': 1, 'total_commands': 4})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
-        self.assertEqual(batch['commands_url'], f'http://testserver/api/v1/batches/{original.pk}/commands/')
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 1")
+        self.assertEqual(batch["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(
+            batch["summary"],
+            {
+                "initial_commands": 1,
+                "error_commands": 1,
+                "running_commands": 1,
+                "done_commands": 1,
+                "total_commands": 4,
+            },
+        )
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
+        self.assertEqual(
+            batch["commands_url"],
+            f"http://testserver/api/v1/batches/{original.pk}/commands/",
+        )
 
     def test_non_allowed_methods_request(self):
-        original = Batch.objects.create(name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING)
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        original = Batch.objects.create(
+            name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.post(reverse("batch-detail", kwargs={"pk": original.pk}))
         self.assertEqual(response.status_code, 405)
         response = self.client.put(reverse("batch-detail", kwargs={"pk": original.pk}))
         self.assertEqual(response.status_code, 405)
-        response = self.client.delete(reverse("batch-detail", kwargs={"pk": original.pk}))
+        response = self.client.delete(
+            reverse("batch-detail", kwargs={"pk": original.pk})
+        )
         self.assertEqual(response.status_code, 405)

--- a/src/api/tests/test_batch_list_view.py
+++ b/src/api/tests/test_batch_list_view.py
@@ -1,4 +1,3 @@
-
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -10,7 +9,7 @@ from core.models import Batch
 
 
 class BatchListViewTest(TestCase):
-    
+
     def setUp(self):
         self.user = User.objects.create(username="myuser")
         self.token = Token.objects.create(user=self.user)
@@ -21,189 +20,237 @@ class BatchListViewTest(TestCase):
         self.assertEqual(response.status_code, 401)
 
     def test_bad_auth_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token fdsfsdfsfsdafsdfsdfsfsdfsad')
+        self.client.credentials(HTTP_AUTHORIZATION="Token fdsfsdfsfsdafsdfsdfsfsdfsad")
         response = self.client.get(reverse("batch-list"))
         self.assertEqual(response.status_code, 401)
 
     def test_empty_authenticated_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("batch-list"))
         self.assertEqual(response.status_code, 200)
 
     def test_single_batch_authenticated_request(self):
         original = Batch.objects.create(name="Batch 0", user="testuser")
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("batch-list"))
         data = response.data
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(data['links']['next'], None)
-        self.assertEqual(data['links']['previous'], None)
-        self.assertEqual(data['total'], 1)
-        self.assertEqual(data['page_size'], 1)
-        self.assertEqual(len(data['batches']), 1)
-        batch = data['batches'][0]
-        self.assertEqual(batch['url'], f'http://testserver/api/v1/batches/{original.pk}/')
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 0')
-        self.assertEqual(batch['status'], {'code': 1, 'display': 'Initial'})
-        self.assertEqual(batch['message'], None)
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
+        self.assertEqual(data["links"]["next"], None)
+        self.assertEqual(data["links"]["previous"], None)
+        self.assertEqual(data["total"], 1)
+        self.assertEqual(data["page_size"], 1)
+        self.assertEqual(len(data["batches"]), 1)
+        batch = data["batches"][0]
+        self.assertEqual(
+            batch["url"], f"http://testserver/api/v1/batches/{original.pk}/"
+        )
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 0")
+        self.assertEqual(batch["status"], {"code": 1, "display": "Initial"})
+        self.assertEqual(batch["message"], None)
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
 
     def test_single_running_batch_authenticated_request(self):
-        original = Batch.objects.create(name="Batch 1", user="testuser", status=Batch.STATUS_RUNNING, message="My running message")
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        original = Batch.objects.create(
+            name="Batch 1",
+            user="testuser",
+            status=Batch.STATUS_RUNNING,
+            message="My running message",
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("batch-list"))
         data = response.data
-        batch = data['batches'][0]
-        self.assertEqual(batch['url'], f'http://testserver/api/v1/batches/{original.pk}/')
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 1')
-        self.assertEqual(batch['status'], {'code': 2, 'display': 'Running'})
-        self.assertEqual(batch['message'], "My running message")
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
+        batch = data["batches"][0]
+        self.assertEqual(
+            batch["url"], f"http://testserver/api/v1/batches/{original.pk}/"
+        )
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 1")
+        self.assertEqual(batch["status"], {"code": 2, "display": "Running"})
+        self.assertEqual(batch["message"], "My running message")
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
 
     def test_single_done_batch_authenticated_request(self):
-        original = Batch.objects.create(name="Batch 2", user="testuser", status=Batch.STATUS_DONE, message="My DONE message")
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        original = Batch.objects.create(
+            name="Batch 2",
+            user="testuser",
+            status=Batch.STATUS_DONE,
+            message="My DONE message",
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("batch-list"))
         data = response.data
-        batch = data['batches'][0]
-        self.assertEqual(batch['url'], f'http://testserver/api/v1/batches/{original.pk}/')
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 2')
-        self.assertEqual(batch['status'], {'code': 3, 'display': 'Done'})
-        self.assertEqual(batch['message'], "My DONE message")
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
+        batch = data["batches"][0]
+        self.assertEqual(
+            batch["url"], f"http://testserver/api/v1/batches/{original.pk}/"
+        )
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 2")
+        self.assertEqual(batch["status"], {"code": 3, "display": "Done"})
+        self.assertEqual(batch["message"], "My DONE message")
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
 
     def test_single_blocked_batch_authenticated_request(self):
-        original = Batch.objects.create(name="Batch 3", user="testuser", status=Batch.STATUS_BLOCKED, message="My BLOCKED message")
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
+        original = Batch.objects.create(
+            name="Batch 3",
+            user="testuser",
+            status=Batch.STATUS_BLOCKED,
+            message="My BLOCKED message",
+        )
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
         response = self.client.get(reverse("batch-list"))
         data = response.data
-        batch = data['batches'][0]
-        self.assertEqual(batch['url'], f'http://testserver/api/v1/batches/{original.pk}/')
-        self.assertEqual(batch['pk'], original.pk)
-        self.assertEqual(batch['user'], 'testuser')
-        self.assertEqual(batch['name'], 'Batch 3')
-        self.assertEqual(batch['status'], {'code': -1, 'display': 'Blocked'})
-        self.assertEqual(batch['message'], "My BLOCKED message")
-        self.assertTrue('created' in batch)
-        self.assertTrue('modified' in batch)
+        batch = data["batches"][0]
+        self.assertEqual(
+            batch["url"], f"http://testserver/api/v1/batches/{original.pk}/"
+        )
+        self.assertEqual(batch["pk"], original.pk)
+        self.assertEqual(batch["user"], "testuser")
+        self.assertEqual(batch["name"], "Batch 3")
+        self.assertEqual(batch["status"], {"code": -1, "display": "Blocked"})
+        self.assertEqual(batch["message"], "My BLOCKED message")
+        self.assertTrue("created" in batch)
+        self.assertTrue("modified" in batch)
 
     def test_authenticated_request(self):
         for user in ["user1", "user2"]:
             for i in range(0, 35):
                 Batch.objects.create(name=f"Batch {i} for {user}", user=user)
 
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
-        
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+
         #####
         # Testing pagination
         #####
         response = self.client.get(reverse("batch-list"))
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], 'http://testserver/api/v1/batches/?page=2')
-        self.assertEqual(data['links']['previous'], None)
-        self.assertEqual(data['total'], 70)
-        self.assertEqual(data['page_size'], 20)
-        self.assertEqual(len(data['batches']), 20)
+        self.assertTrue("links" in data)
+        self.assertEqual(
+            data["links"]["next"], "http://testserver/api/v1/batches/?page=2"
+        )
+        self.assertEqual(data["links"]["previous"], None)
+        self.assertEqual(data["total"], 70)
+        self.assertEqual(data["page_size"], 20)
+        self.assertEqual(len(data["batches"]), 20)
 
-        response = self.client.get('http://testserver/api/v1/batches/?page=2')
+        response = self.client.get("http://testserver/api/v1/batches/?page=2")
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], 'http://testserver/api/v1/batches/?page=3')
-        self.assertEqual(data['links']['previous'], 'http://testserver/api/v1/batches/')
-        self.assertEqual(data['total'], 70)
-        self.assertEqual(data['page_size'], 20)
-        self.assertEqual(len(data['batches']), 20)
+        self.assertTrue("links" in data)
+        self.assertEqual(
+            data["links"]["next"], "http://testserver/api/v1/batches/?page=3"
+        )
+        self.assertEqual(data["links"]["previous"], "http://testserver/api/v1/batches/")
+        self.assertEqual(data["total"], 70)
+        self.assertEqual(data["page_size"], 20)
+        self.assertEqual(len(data["batches"]), 20)
 
-        response = self.client.get('http://testserver/api/v1/batches/?page=3')
+        response = self.client.get("http://testserver/api/v1/batches/?page=3")
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], 'http://testserver/api/v1/batches/?page=4')
-        self.assertEqual(data['links']['previous'], 'http://testserver/api/v1/batches/?page=2')
-        self.assertEqual(data['total'], 70)
-        self.assertEqual(data['page_size'], 20)
-        self.assertEqual(len(data['batches']), 20)
+        self.assertTrue("links" in data)
+        self.assertEqual(
+            data["links"]["next"], "http://testserver/api/v1/batches/?page=4"
+        )
+        self.assertEqual(
+            data["links"]["previous"], "http://testserver/api/v1/batches/?page=2"
+        )
+        self.assertEqual(data["total"], 70)
+        self.assertEqual(data["page_size"], 20)
+        self.assertEqual(len(data["batches"]), 20)
 
-        response = self.client.get('http://testserver/api/v1/batches/?page=4')
+        response = self.client.get("http://testserver/api/v1/batches/?page=4")
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], None)
-        self.assertEqual(data['links']['previous'], 'http://testserver/api/v1/batches/?page=3')
-        self.assertEqual(data['total'], 70)
-        self.assertEqual(data['page_size'], 10)
-        self.assertEqual(len(data['batches']), 10)
+        self.assertTrue("links" in data)
+        self.assertEqual(data["links"]["next"], None)
+        self.assertEqual(
+            data["links"]["previous"], "http://testserver/api/v1/batches/?page=3"
+        )
+        self.assertEqual(data["total"], 70)
+        self.assertEqual(data["page_size"], 10)
+        self.assertEqual(len(data["batches"]), 10)
 
         #####
         # Testing filter by user1
         #####
-        response = self.client.get('http://testserver/api/v1/batches/?username=user1')
+        response = self.client.get("http://testserver/api/v1/batches/?username=user1")
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], 'http://testserver/api/v1/batches/?page=2&username=user1')
-        self.assertEqual(data['links']['previous'], None)
-        self.assertEqual(data['total'], 35)
-        self.assertEqual(data['page_size'], 20)
-        self.assertEqual(len(data['batches']), 20)
-        for b in data['batches']:
-            self.assertEqual(b['user'], 'user1')
+        self.assertTrue("links" in data)
+        self.assertEqual(
+            data["links"]["next"],
+            "http://testserver/api/v1/batches/?page=2&username=user1",
+        )
+        self.assertEqual(data["links"]["previous"], None)
+        self.assertEqual(data["total"], 35)
+        self.assertEqual(data["page_size"], 20)
+        self.assertEqual(len(data["batches"]), 20)
+        for b in data["batches"]:
+            self.assertEqual(b["user"], "user1")
 
-        response = self.client.get('http://testserver/api/v1/batches/?username=user1&page=2')
+        response = self.client.get(
+            "http://testserver/api/v1/batches/?username=user1&page=2"
+        )
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], None)
-        self.assertEqual(data['links']['previous'], 'http://testserver/api/v1/batches/?username=user1')
-        self.assertEqual(data['total'], 35)
-        self.assertEqual(data['page_size'], 15)
-        self.assertEqual(len(data['batches']), 15)
-        for b in data['batches']:
-            self.assertEqual(b['user'], 'user1')
+        self.assertTrue("links" in data)
+        self.assertEqual(data["links"]["next"], None)
+        self.assertEqual(
+            data["links"]["previous"],
+            "http://testserver/api/v1/batches/?username=user1",
+        )
+        self.assertEqual(data["total"], 35)
+        self.assertEqual(data["page_size"], 15)
+        self.assertEqual(len(data["batches"]), 15)
+        for b in data["batches"]:
+            self.assertEqual(b["user"], "user1")
 
         #####
         # Testing filter by user2
         #####
-        response = self.client.get('http://testserver/api/v1/batches/?username=user2')
+        response = self.client.get("http://testserver/api/v1/batches/?username=user2")
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], 'http://testserver/api/v1/batches/?page=2&username=user2')
-        self.assertEqual(data['links']['previous'], None)
-        self.assertEqual(data['total'], 35)
-        self.assertEqual(data['page_size'], 20)
-        self.assertEqual(len(data['batches']), 20)
-        for b in data['batches']:
-            self.assertEqual(b['user'], 'user2')
+        self.assertTrue("links" in data)
+        self.assertEqual(
+            data["links"]["next"],
+            "http://testserver/api/v1/batches/?page=2&username=user2",
+        )
+        self.assertEqual(data["links"]["previous"], None)
+        self.assertEqual(data["total"], 35)
+        self.assertEqual(data["page_size"], 20)
+        self.assertEqual(len(data["batches"]), 20)
+        for b in data["batches"]:
+            self.assertEqual(b["user"], "user2")
 
-        response = self.client.get('http://testserver/api/v1/batches/?username=user2&page=2')
+        response = self.client.get(
+            "http://testserver/api/v1/batches/?username=user2&page=2"
+        )
         self.assertEqual(response.status_code, 200)
         data = response.data
-        self.assertTrue('links' in data)
-        self.assertEqual(data['links']['next'], None)
-        self.assertEqual(data['links']['previous'], 'http://testserver/api/v1/batches/?username=user2')
-        self.assertEqual(data['total'], 35)
-        self.assertEqual(data['page_size'], 15)
-        self.assertEqual(len(data['batches']), 15)
-        for b in data['batches']:
-            self.assertEqual(b['user'], 'user2')
-
+        self.assertTrue("links" in data)
+        self.assertEqual(data["links"]["next"], None)
+        self.assertEqual(
+            data["links"]["previous"],
+            "http://testserver/api/v1/batches/?username=user2",
+        )
+        self.assertEqual(data["total"], 35)
+        self.assertEqual(data["page_size"], 15)
+        self.assertEqual(len(data["batches"]), 15)
+        for b in data["batches"]:
+            self.assertEqual(b["user"], "user2")
 
     def test_non_allowed_methods_request(self):
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token.key)
-        
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token.key)
+
         response = self.client.post(reverse("batch-list"))
         self.assertEqual(response.status_code, 405)
 

--- a/src/api/urls.py
+++ b/src/api/urls.py
@@ -1,14 +1,21 @@
-
 from django.urls import path
 from rest_framework.urlpatterns import format_suffix_patterns
 from api import views
 
 
 urlpatterns = [
-    path('batches/', views.BatchListView.as_view(), name="batch-list"),
-    path('batches/<int:pk>/', views.BatchDetailView.as_view(), name="batch-detail"),
-    path('batches/<int:batchpk>/commands/', views.BatchCommandListView.as_view(), name="command-list"),
-    path('commands/<int:pk>', views.BatchCommandDetailView.as_view(), name="command-detail"),
+    path("batches/", views.BatchListView.as_view(), name="batch-list"),
+    path("batches/<int:pk>/", views.BatchDetailView.as_view(), name="batch-detail"),
+    path(
+        "batches/<int:batchpk>/commands/",
+        views.BatchCommandListView.as_view(),
+        name="command-list",
+    ),
+    path(
+        "commands/<int:pk>",
+        views.BatchCommandDetailView.as_view(),
+        name="command-detail",
+    ),
 ]
 
 urlpatterns = format_suffix_patterns(urlpatterns)

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,4 +1,3 @@
-
 from django.http import Http404
 
 from rest_framework import generics
@@ -21,6 +20,7 @@ class BatchListView(generics.GenericAPIView, mixins.ListModelMixin):
     """
     Available batches listing
     """
+
     pagination_class = CustomPagination
     serializer_class = BatchListSerializer
 
@@ -45,6 +45,7 @@ class BatchDetailView(generics.GenericAPIView, mixins.RetrieveModelMixin):
     """
     Batch detail
     """
+
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
@@ -53,14 +54,24 @@ class BatchDetailView(generics.GenericAPIView, mixins.RetrieveModelMixin):
 
     def get_object(self):
         from django.db.models import Q, Count
+
         try:
-            error_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_ERROR))
-            initial_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_INITIAL))
-            running_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_RUNNING))
-            done_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_DONE))
+            error_commands = Count(
+                "batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_ERROR)
+            )
+            initial_commands = Count(
+                "batchcommand",
+                filter=Q(batchcommand__status=BatchCommand.STATUS_INITIAL),
+            )
+            running_commands = Count(
+                "batchcommand",
+                filter=Q(batchcommand__status=BatchCommand.STATUS_RUNNING),
+            )
+            done_commands = Count(
+                "batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_DONE)
+            )
             batch = (
-                Batch.objects
-                .annotate(error_commands=error_commands)
+                Batch.objects.annotate(error_commands=error_commands)
                 .annotate(initial_commands=initial_commands)
                 .annotate(running_commands=running_commands)
                 .annotate(done_commands=done_commands)
@@ -79,14 +90,21 @@ class BatchCommandListView(generics.GenericAPIView, mixins.ListModelMixin):
     """
     Batch commands listing. Uses pagination.
     """
-    authentication_classes = [TokenAuthentication,]
+
+    authentication_classes = [
+        TokenAuthentication,
+    ]
     permission_classes = [IsAuthenticated]
 
     pagination_class = CustomBatchCommandPagination
     serializer_class = BatchCommandListSerializer
 
     def get_queryset(self):
-        return BatchCommand.objects.select_related("batch").filter(batch__pk=self.kwargs["batchpk"]).order_by("index")
+        return (
+            BatchCommand.objects.select_related("batch")
+            .filter(batch__pk=self.kwargs["batchpk"])
+            .order_by("index")
+        )
 
     def get(self, request, *args, **kwargs):
         try:
@@ -101,6 +119,7 @@ class BatchCommandDetailView(generics.GenericAPIView, mixins.RetrieveModelMixin)
     """
     Batch command detail
     """
+
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 

--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -7,7 +7,15 @@ from core.models import BatchCommand
 @admin.register(BatchCommand)
 class BatchCommandAdmin(admin.ModelAdmin):
     list_select_related = ["batch"]
-    list_display = ["batch", "index", "operation", "status", "error", "created", "modified"]
+    list_display = [
+        "batch",
+        "index",
+        "operation",
+        "status",
+        "error",
+        "created",
+        "modified",
+    ]
     list_filter = ["operation", "status", "error", "created", "modified"]
     search_field = ["batch__name", "batch__user"]
     raw_id_fields = ["batch"]

--- a/src/core/apps.py
+++ b/src/core/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class CoreConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'core'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "core"

--- a/src/core/client.py
+++ b/src/core/client.py
@@ -316,7 +316,9 @@ class Client:
             "languages": languages,
             "ids": ids,
         }
-        logger.debug(f"Sending GET request at {action_api}, languages={languages}, ids={ids}")
+        logger.debug(
+            f"Sending GET request at {action_api}, languages={languages}, ids={ids}"
+        )
         self.refresh_token_if_needed()
         res = requests.get(action_api, headers=self.headers(), params=params)
         self.raise_for_status(res)

--- a/src/core/migrations/0001_initial.py
+++ b/src/core/migrations/0001_initial.py
@@ -8,53 +8,112 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='Batch',
+            name="Batch",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('name', models.CharField(max_length=255)),
-                ('user', models.CharField(db_index=True, max_length=128)),
-                ('status', models.IntegerField(choices=[(-1, 'Blocked'), (0, 'Initial'), (1, 'Running'), (2, 'Done')], default=0)),
-                ('message', models.TextField()),
-                ('created', models.DateTimeField(auto_now_add=True)),
-                ('modified', models.DateTimeField(auto_now=True)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("user", models.CharField(db_index=True, max_length=128)),
+                (
+                    "status",
+                    models.IntegerField(
+                        choices=[
+                            (-1, "Blocked"),
+                            (0, "Initial"),
+                            (1, "Running"),
+                            (2, "Done"),
+                        ],
+                        default=0,
+                    ),
+                ),
+                ("message", models.TextField()),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("modified", models.DateTimeField(auto_now=True)),
             ],
             options={
-                'verbose_name': 'Batch',
-                'verbose_name_plural': 'Batches',
+                "verbose_name": "Batch",
+                "verbose_name_plural": "Batches",
             },
         ),
         migrations.CreateModel(
-            name='BatchAdmin',
+            name="BatchAdmin",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='BatchCommandAdmin',
+            name="BatchCommandAdmin",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='BatchCommand',
+            name="BatchCommand",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('index', models.IntegerField()),
-                ('json', models.JSONField()),
-                ('status', models.IntegerField(choices=[(-1, 'Error'), (0, 'Initial'), (1, 'Running'), (2, 'Done')], db_index=True, default=0)),
-                ('message', models.TextField()),
-                ('created', models.DateTimeField(auto_now_add=True)),
-                ('modified', models.DateTimeField(auto_now=True)),
-                ('batch', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='core.batch')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("index", models.IntegerField()),
+                ("json", models.JSONField()),
+                (
+                    "status",
+                    models.IntegerField(
+                        choices=[
+                            (-1, "Error"),
+                            (0, "Initial"),
+                            (1, "Running"),
+                            (2, "Done"),
+                        ],
+                        db_index=True,
+                        default=0,
+                    ),
+                ),
+                ("message", models.TextField()),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("modified", models.DateTimeField(auto_now=True)),
+                (
+                    "batch",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE, to="core.batch"
+                    ),
+                ),
             ],
             options={
-                'verbose_name': 'Batch Command',
-                'verbose_name_plural': 'Batch Commands',
+                "verbose_name": "Batch Command",
+                "verbose_name_plural": "Batch Commands",
             },
         ),
     ]

--- a/src/core/migrations/0002_delete_batchadmin_delete_batchcommandadmin_and_more.py
+++ b/src/core/migrations/0002_delete_batchadmin_delete_batchcommandadmin_and_more.py
@@ -6,24 +6,24 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0001_initial'),
+        ("core", "0001_initial"),
     ]
 
     operations = [
         migrations.DeleteModel(
-            name='BatchAdmin',
+            name="BatchAdmin",
         ),
         migrations.DeleteModel(
-            name='BatchCommandAdmin',
+            name="BatchCommandAdmin",
         ),
         migrations.AlterField(
-            model_name='batch',
-            name='created',
+            model_name="batch",
+            name="created",
             field=models.DateTimeField(auto_now_add=True, db_index=True),
         ),
         migrations.AlterField(
-            model_name='batch',
-            name='modified',
+            model_name="batch",
+            name="modified",
             field=models.DateTimeField(auto_now=True, db_index=True),
         ),
     ]

--- a/src/core/migrations/0003_alter_batch_created_alter_batch_modified_and_more.py
+++ b/src/core/migrations/0003_alter_batch_created_alter_batch_modified_and_more.py
@@ -6,23 +6,26 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0002_delete_batchadmin_delete_batchcommandadmin_and_more'),
+        ("core", "0002_delete_batchadmin_delete_batchcommandadmin_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batch',
-            name='created',
+            model_name="batch",
+            name="created",
             field=models.DateTimeField(auto_now_add=True),
         ),
         migrations.AlterField(
-            model_name='batch',
-            name='modified',
+            model_name="batch",
+            name="modified",
             field=models.DateTimeField(auto_now=True),
         ),
         migrations.AlterField(
-            model_name='batch',
-            name='status',
-            field=models.IntegerField(choices=[(-1, 'Blocked'), (0, 'Initial'), (1, 'Running'), (2, 'Done')], default=0),
+            model_name="batch",
+            name="status",
+            field=models.IntegerField(
+                choices=[(-1, "Blocked"), (0, "Initial"), (1, "Running"), (2, "Done")],
+                default=0,
+            ),
         ),
     ]

--- a/src/core/migrations/0004_alter_batch_message.py
+++ b/src/core/migrations/0004_alter_batch_message.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0003_alter_batch_created_alter_batch_modified_and_more'),
+        ("core", "0003_alter_batch_created_alter_batch_modified_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batch',
-            name='message',
+            model_name="batch",
+            name="message",
             field=models.TextField(blank=True, null=True),
         ),
     ]

--- a/src/core/migrations/0005_batchcommand_raw_alter_batchcommand_message_and_more.py
+++ b/src/core/migrations/0005_batchcommand_raw_alter_batchcommand_message_and_more.py
@@ -6,24 +6,28 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0004_alter_batch_message'),
+        ("core", "0004_alter_batch_message"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='batchcommand',
-            name='raw',
-            field=models.TextField(default=''),
+            model_name="batchcommand",
+            name="raw",
+            field=models.TextField(default=""),
             preserve_default=False,
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='message',
+            model_name="batchcommand",
+            name="message",
             field=models.TextField(blank=True, null=True),
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='status',
-            field=models.IntegerField(choices=[(-1, 'Error'), (0, 'Initial'), (1, 'Running'), (2, 'Done')], db_index=True, default=0),
+            model_name="batchcommand",
+            name="status",
+            field=models.IntegerField(
+                choices=[(-1, "Error"), (0, "Initial"), (1, "Running"), (2, "Done")],
+                db_index=True,
+                default=0,
+            ),
         ),
     ]

--- a/src/core/migrations/0006_batchcommand_action.py
+++ b/src/core/migrations/0006_batchcommand_action.py
@@ -6,13 +6,16 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0005_batchcommand_raw_alter_batchcommand_message_and_more'),
+        ("core", "0005_batchcommand_raw_alter_batchcommand_message_and_more"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='batchcommand',
-            name='action',
-            field=models.IntegerField(choices=[(0, 'CREATE'), (1, 'ADD'), (2, 'REMOVE'), (3, 'MERGE')], default=0),
+            model_name="batchcommand",
+            name="action",
+            field=models.IntegerField(
+                choices=[(0, "CREATE"), (1, "ADD"), (2, "REMOVE"), (3, "MERGE")],
+                default=0,
+            ),
         ),
     ]

--- a/src/core/migrations/0007_alter_batch_modified_and_more.py
+++ b/src/core/migrations/0007_alter_batch_modified_and_more.py
@@ -6,17 +6,17 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0006_batchcommand_action'),
+        ("core", "0006_batchcommand_action"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batch',
-            name='modified',
+            model_name="batch",
+            name="modified",
             field=models.DateTimeField(auto_now=True, db_index=True),
         ),
         migrations.AlterIndexTogether(
-            name='batchcommand',
-            index_together={('batch', 'index')},
+            name="batchcommand",
+            index_together={("batch", "index")},
         ),
     ]

--- a/src/core/migrations/0009_batchcommand_response_json.py
+++ b/src/core/migrations/0009_batchcommand_response_json.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0008_alter_batch_status'),
+        ("core", "0008_alter_batch_status"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='batchcommand',
-            name='response_json',
+            model_name="batchcommand",
+            name="response_json",
             field=models.JSONField(default=dict),
         ),
     ]

--- a/src/core/migrations/0011_alter_batch_status.py
+++ b/src/core/migrations/0011_alter_batch_status.py
@@ -6,13 +6,23 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0010_batchcommand_data_type_verified'),
+        ("core", "0010_batchcommand_data_type_verified"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batch',
-            name='status',
-            field=models.IntegerField(choices=[(-2, 'Stopped'), (-1, 'Blocked'), (0, 'Initial'), (1, 'Running'), (2, 'Done')], db_index=True, default=0),
+            model_name="batch",
+            name="status",
+            field=models.IntegerField(
+                choices=[
+                    (-2, "Stopped"),
+                    (-1, "Blocked"),
+                    (0, "Initial"),
+                    (1, "Running"),
+                    (2, "Done"),
+                ],
+                db_index=True,
+                default=0,
+            ),
         ),
     ]

--- a/src/core/migrations/0012_batch_block_on_errors.py
+++ b/src/core/migrations/0012_batch_block_on_errors.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0011_alter_batch_status'),
+        ("core", "0011_alter_batch_status"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='batch',
-            name='block_on_errors',
+            model_name="batch",
+            name="block_on_errors",
             field=models.BooleanField(default=False),
         ),
     ]

--- a/src/core/migrations/0012_rename_data_type_verified_batchcommand_value_type_verified.py
+++ b/src/core/migrations/0012_rename_data_type_verified_batchcommand_value_type_verified.py
@@ -6,13 +6,13 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0011_alter_batch_status'),
+        ("core", "0011_alter_batch_status"),
     ]
 
     operations = [
         migrations.RenameField(
-            model_name='batchcommand',
-            old_name='data_type_verified',
-            new_name='value_type_verified',
+            model_name="batchcommand",
+            old_name="data_type_verified",
+            new_name="value_type_verified",
         ),
     ]

--- a/src/core/migrations/0013_merge_20241003_1539.py
+++ b/src/core/migrations/0013_merge_20241003_1539.py
@@ -6,9 +6,8 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0012_batch_block_on_errors'),
-        ('core', '0012_rename_data_type_verified_batchcommand_value_type_verified'),
+        ("core", "0012_batch_block_on_errors"),
+        ("core", "0012_rename_data_type_verified_batchcommand_value_type_verified"),
     ]
 
-    operations = [
-    ]
+    operations = []

--- a/src/core/migrations/0015_alter_batch_status.py
+++ b/src/core/migrations/0015_alter_batch_status.py
@@ -6,13 +6,24 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0014_move_status_codes'),
+        ("core", "0014_move_status_codes"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batch',
-            name='status',
-            field=models.IntegerField(choices=[(-2, 'Stopped'), (-1, 'Blocked'), (0, 'Preview'), (1, 'Initial'), (2, 'Running'), (3, 'Done')], db_index=True, default=1),
+            model_name="batch",
+            name="status",
+            field=models.IntegerField(
+                choices=[
+                    (-2, "Stopped"),
+                    (-1, "Blocked"),
+                    (0, "Preview"),
+                    (1, "Initial"),
+                    (2, "Running"),
+                    (3, "Done"),
+                ],
+                db_index=True,
+                default=1,
+            ),
         ),
     ]

--- a/src/core/migrations/0017_batchcommand_operation.py
+++ b/src/core/migrations/0017_batchcommand_operation.py
@@ -6,13 +6,13 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0016_batchcommand_user_summary'),
+        ("core", "0016_batchcommand_user_summary"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(choices=[('create_item', 'Create item')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(choices=[("create_item", "Create item")], null=True),
         ),
     ]

--- a/src/core/migrations/0018_batchcommand_error_alter_batchcommand_operation_and_more.py
+++ b/src/core/migrations/0018_batchcommand_error_alter_batchcommand_operation_and_more.py
@@ -6,23 +6,34 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0017_batchcommand_operation'),
+        ("core", "0017_batchcommand_operation"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='batchcommand',
-            name='error',
-            field=models.TextField(blank=True, choices=[('op_not_implemented', 'Operation not implemented')], null=True),
+            model_name="batchcommand",
+            name="error",
+            field=models.TextField(
+                blank=True,
+                choices=[("op_not_implemented", "Operation not implemented")],
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                ],
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='response_json',
+            model_name="batchcommand",
+            name="response_json",
             field=models.JSONField(blank=True, default=dict),
         ),
     ]

--- a/src/core/migrations/0019_alter_batchcommand_operation.py
+++ b/src/core/migrations/0019_alter_batchcommand_operation.py
@@ -6,13 +6,21 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0018_batchcommand_error_alter_batchcommand_operation_and_more'),
+        ("core", "0018_batchcommand_error_alter_batchcommand_operation_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property'), ('remove_statement_by_id', 'Remove statement by id')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                    ("remove_statement_by_id", "Remove statement by id"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/migrations/0020_alter_batchcommand_error_and_more.py
+++ b/src/core/migrations/0020_alter_batchcommand_error_and_more.py
@@ -6,18 +6,35 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0019_alter_batchcommand_operation'),
+        ("core", "0019_alter_batchcommand_operation"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batchcommand',
-            name='error',
-            field=models.TextField(blank=True, choices=[('op_not_implemented', 'Operation not implemented'), ('no_statements_property', 'No statements for given property'), ('no_statements_value', 'No statements with given value')], null=True),
+            model_name="batchcommand",
+            name="error",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("op_not_implemented", "Operation not implemented"),
+                    ("no_statements_property", "No statements for given property"),
+                    ("no_statements_value", "No statements with given value"),
+                ],
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property'), ('remove_statement_by_id', 'Remove statement by id'), ('remove_statement_by_value', 'Remove statement by value')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                    ("remove_statement_by_id", "Remove statement by id"),
+                    ("remove_statement_by_value", "Remove statement by value"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/migrations/0021_alter_batchcommand_error_and_more.py
+++ b/src/core/migrations/0021_alter_batchcommand_error_and_more.py
@@ -6,18 +6,37 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0020_alter_batchcommand_error_and_more'),
+        ("core", "0020_alter_batchcommand_error_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batchcommand',
-            name='error',
-            field=models.TextField(blank=True, choices=[('op_not_implemented', 'Operation not implemented'), ('no_statements_property', 'No statements for given property'), ('no_statements_value', 'No statements with given value'), ('sitelink_invalid', 'The sitelink id is invalid')], null=True),
+            model_name="batchcommand",
+            name="error",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("op_not_implemented", "Operation not implemented"),
+                    ("no_statements_property", "No statements for given property"),
+                    ("no_statements_value", "No statements with given value"),
+                    ("sitelink_invalid", "The sitelink id is invalid"),
+                ],
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property'), ('remove_statement_by_id', 'Remove statement by id'), ('remove_statement_by_value', 'Remove statement by value'), ('set_sitelink', 'Set sitelink')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                    ("remove_statement_by_id", "Remove statement by id"),
+                    ("remove_statement_by_value", "Remove statement by value"),
+                    ("set_sitelink", "Set sitelink"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/migrations/0022_alter_batchcommand_operation.py
+++ b/src/core/migrations/0022_alter_batchcommand_operation.py
@@ -6,13 +6,24 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0021_alter_batchcommand_error_and_more'),
+        ("core", "0021_alter_batchcommand_error_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property'), ('remove_statement_by_id', 'Remove statement by id'), ('remove_statement_by_value', 'Remove statement by value'), ('set_sitelink', 'Set sitelink'), ('remove_sitelink', 'Remove sitelink')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                    ("remove_statement_by_id", "Remove statement by id"),
+                    ("remove_statement_by_value", "Remove statement by value"),
+                    ("set_sitelink", "Set sitelink"),
+                    ("remove_sitelink", "Remove sitelink"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/migrations/0023_alter_batchcommand_operation.py
+++ b/src/core/migrations/0023_alter_batchcommand_operation.py
@@ -6,13 +6,31 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0022_alter_batchcommand_operation'),
+        ("core", "0022_alter_batchcommand_operation"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property'), ('set_statement', 'Set statement'), ('remove_statement_by_id', 'Remove statement by id'), ('remove_statement_by_value', 'Remove statement by value'), ('set_sitelink', 'Set sitelink'), ('set_label', 'Set label'), ('set_description', 'Set label'), ('remove_sitelink', 'Remove sitelink'), ('remove_label', 'Remove label'), ('remove_description', 'Remove description'), ('add_alias', 'Add alias'), ('remove_alias', 'Remove alias')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                    ("set_statement", "Set statement"),
+                    ("remove_statement_by_id", "Remove statement by id"),
+                    ("remove_statement_by_value", "Remove statement by value"),
+                    ("set_sitelink", "Set sitelink"),
+                    ("set_label", "Set label"),
+                    ("set_description", "Set label"),
+                    ("remove_sitelink", "Remove sitelink"),
+                    ("remove_label", "Remove label"),
+                    ("remove_description", "Remove description"),
+                    ("add_alias", "Add alias"),
+                    ("remove_alias", "Remove alias"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/migrations/0024_batch_combine_commands_alter_batchcommand_operation.py
+++ b/src/core/migrations/0024_batch_combine_commands_alter_batchcommand_operation.py
@@ -6,18 +6,36 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0023_alter_batchcommand_operation'),
+        ("core", "0023_alter_batchcommand_operation"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='batch',
-            name='combine_commands',
+            model_name="batch",
+            name="combine_commands",
             field=models.BooleanField(default=False),
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property'), ('set_statement', 'Set statement'), ('remove_statement_by_id', 'Remove statement by id'), ('remove_statement_by_value', 'Remove statement by value'), ('set_sitelink', 'Set sitelink'), ('set_label', 'Set label'), ('set_description', 'Set description'), ('remove_sitelink', 'Remove sitelink'), ('remove_label', 'Remove label'), ('remove_description', 'Remove description'), ('add_alias', 'Add alias'), ('remove_alias', 'Remove alias')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                    ("set_statement", "Set statement"),
+                    ("remove_statement_by_id", "Remove statement by id"),
+                    ("remove_statement_by_value", "Remove statement by value"),
+                    ("set_sitelink", "Set sitelink"),
+                    ("set_label", "Set label"),
+                    ("set_description", "Set description"),
+                    ("remove_sitelink", "Remove sitelink"),
+                    ("remove_label", "Remove label"),
+                    ("remove_description", "Remove description"),
+                    ("add_alias", "Add alias"),
+                    ("remove_alias", "Remove alias"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/migrations/0025_alter_batchcommand_error.py
+++ b/src/core/migrations/0025_alter_batchcommand_error.py
@@ -6,13 +6,23 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0024_batch_combine_commands_alter_batchcommand_operation'),
+        ("core", "0024_batch_combine_commands_alter_batchcommand_operation"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batchcommand',
-            name='error',
-            field=models.TextField(blank=True, choices=[('op_not_implemented', 'Operation not implemented'), ('no_statements_property', 'No statements for given property'), ('no_statements_value', 'No statements with given value'), ('sitelink_invalid', 'The sitelink id is invalid'), ('combining_failed', 'The next command failed')], null=True),
+            model_name="batchcommand",
+            name="error",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("op_not_implemented", "Operation not implemented"),
+                    ("no_statements_property", "No statements for given property"),
+                    ("no_statements_value", "No statements with given value"),
+                    ("sitelink_invalid", "The sitelink id is invalid"),
+                    ("combining_failed", "The next command failed"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/migrations/0026_alter_batchcommand_error_and_more.py
+++ b/src/core/migrations/0026_alter_batchcommand_error_and_more.py
@@ -6,18 +6,54 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('core', '0025_alter_batchcommand_error'),
+        ("core", "0025_alter_batchcommand_error"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='batchcommand',
-            name='error',
-            field=models.TextField(blank=True, choices=[('op_not_implemented', 'Operation not implemented'), ('no_statements_property', 'No statements for given property'), ('no_statements_value', 'No statements with given value'), ('no_qualifiers', 'No qualifiers with given value'), ('no_reference_parts', 'No reference parts with given value'), ('sitelink_invalid', 'The sitelink id is invalid'), ('combining_failed', 'The next command failed'), ('api_user_error', 'API returned a User error'), ('api_server_error', 'API returned a server error'), ('last_not_evaluated', 'LAST could not be evaluated.')], null=True),
+            model_name="batchcommand",
+            name="error",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("op_not_implemented", "Operation not implemented"),
+                    ("no_statements_property", "No statements for given property"),
+                    ("no_statements_value", "No statements with given value"),
+                    ("no_qualifiers", "No qualifiers with given value"),
+                    ("no_reference_parts", "No reference parts with given value"),
+                    ("sitelink_invalid", "The sitelink id is invalid"),
+                    ("combining_failed", "The next command failed"),
+                    ("api_user_error", "API returned a User error"),
+                    ("api_server_error", "API returned a server error"),
+                    ("last_not_evaluated", "LAST could not be evaluated."),
+                ],
+                null=True,
+            ),
         ),
         migrations.AlterField(
-            model_name='batchcommand',
-            name='operation',
-            field=models.TextField(blank=True, choices=[('create_item', 'Create item'), ('create_property', 'Create property'), ('set_statement', 'Set statement'), ('create_statement', 'Create statement'), ('remove_statement_by_id', 'Remove statement by id'), ('remove_statement_by_value', 'Remove statement by value'), ('remove_qualifier', 'Remove qualifier'), ('remove_reference', 'Remove reference'), ('set_sitelink', 'Set sitelink'), ('set_label', 'Set label'), ('set_description', 'Set description'), ('remove_sitelink', 'Remove sitelink'), ('remove_label', 'Remove label'), ('remove_description', 'Remove description'), ('add_alias', 'Add alias'), ('remove_alias', 'Remove alias')], null=True),
+            model_name="batchcommand",
+            name="operation",
+            field=models.TextField(
+                blank=True,
+                choices=[
+                    ("create_item", "Create item"),
+                    ("create_property", "Create property"),
+                    ("set_statement", "Set statement"),
+                    ("create_statement", "Create statement"),
+                    ("remove_statement_by_id", "Remove statement by id"),
+                    ("remove_statement_by_value", "Remove statement by value"),
+                    ("remove_qualifier", "Remove qualifier"),
+                    ("remove_reference", "Remove reference"),
+                    ("set_sitelink", "Set sitelink"),
+                    ("set_label", "Set label"),
+                    ("set_description", "Set description"),
+                    ("remove_sitelink", "Remove sitelink"),
+                    ("remove_label", "Remove label"),
+                    ("remove_description", "Remove description"),
+                    ("add_alias", "Add alias"),
+                    ("remove_alias", "Remove alias"),
+                ],
+                null=True,
+            ),
         ),
     ]

--- a/src/core/parsers/base.py
+++ b/src/core/parsers/base.py
@@ -1,7 +1,7 @@
-
 import re
 
 from decimal import Decimal
+
 
 class ParserException(Exception):
     def __init__(self, message):
@@ -13,6 +13,7 @@ class BaseParser(object):
     """
     Base parser. Can parse basic data ids for wikidata
     """
+
     def is_valid_property_id(self, value):
         """
         Returns True if value is a valid PROPERTY ID
@@ -55,7 +56,8 @@ class BaseParser(object):
         MXXXXX
         """
         return value is not None and (
-            re.match("^Q\\d+$", value) is not None or re.match("^M\\d+$", value) is not None
+            re.match("^Q\\d+$", value) is not None
+            or re.match("^M\\d+$", value) is not None
         )
 
     def is_valid_entity_id(self, value):
@@ -71,7 +73,8 @@ class BaseParser(object):
 
         """
         return value is not None and (
-            re.match(r"^[QMPL]\d+$", value) is not None or re.match(r"^L\d+\-[FS]\d+$", value) is not None
+            re.match(r"^[QMPL]\d+$", value) is not None
+            or re.match(r"^L\d+\-[FS]\d+$", value) is not None
         )
 
     def is_valid_label(self, value):
@@ -111,11 +114,14 @@ class BaseParser(object):
         Rdeprecated,  Rnormal,  Rpreferred
         R=, R0, R+
         """
-        return value is not None and re.match(r"^R(-|0|\+|deprecated|normal|preferred)$", value) is not None
+        return (
+            value is not None
+            and re.match(r"^R(-|0|\+|deprecated|normal|preferred)$", value) is not None
+        )
 
     def get_entity_type(self, entity):
         """
-        Detects the entity type based on the pattern. 
+        Detects the entity type based on the pattern.
         Returns item, property, lexeme, form, sense if its a valid pattern.
         Returns None otherwise
         """
@@ -147,7 +153,7 @@ class BaseParser(object):
 
     def parse_value_somevalue_novalue(self, v):
         """
-        Returns somevalue data if v matches somevalue or novalue 
+        Returns somevalue data if v matches somevalue or novalue
         Returns None otherwise
         """
         if v in ["somevalue", "novalue"]:
@@ -185,7 +191,10 @@ class BaseParser(object):
         """
         string_match = re.match(r'^"(.*)"$', v)
         if string_match:
-            return {"type": "string", "value": self.convert_to_utf8(string_match.group(1)).strip()}
+            return {
+                "type": "string",
+                "value": self.convert_to_utf8(string_match.group(1)).strip(),
+            }
         return None
 
     def parse_value_monolingualtext(self, v):
@@ -203,7 +212,9 @@ class BaseParser(object):
                 "type": "monolingualtext",
                 "value": {
                     "language": monolingualtext_match.group(1),
-                    "text": self.convert_to_utf8(monolingualtext_match.group(2)).strip(),
+                    "text": self.convert_to_utf8(
+                        monolingualtext_match.group(2)
+                    ).strip(),
                 },
             }
         return None
@@ -222,7 +233,7 @@ class BaseParser(object):
             return {
                 # TODO: maybe implement again data_type: url
                 "type": "string",
-                "value": url_match.group(1)
+                "value": url_match.group(1),
             }
         return None
 
@@ -239,7 +250,7 @@ class BaseParser(object):
             return {
                 # TODO: maybe implement again data_type: commonsMedia
                 "type": "string",
-                "value": url_match.group(1)
+                "value": url_match.group(1),
             }
         return None
 
@@ -256,7 +267,7 @@ class BaseParser(object):
             return {
                 # TODO: maybe implement again data_type: commonsMedia
                 "type": "string",
-                "value": id_match.group(1)
+                "value": id_match.group(1),
             }
         return None
 
@@ -268,7 +279,10 @@ class BaseParser(object):
 
         Returns None otherwise
         """
-        time_match = re.match(r"^([+-]{0,1})(\d+)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z\/{0,1}(\d*)(\/J){0,1}$", v)
+        time_match = re.match(
+            r"^([+-]{0,1})(\d+)-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)Z\/{0,1}(\d*)(\/J){0,1}$",
+            v,
+        )
         if time_match:
             prec = 9
             if time_match.group(8):
@@ -281,9 +295,11 @@ class BaseParser(object):
                 "value": {
                     "time": re.sub(r"/\d+$", "", v),
                     "precision": prec,
-                    "calendarmodel": "http://www.wikidata.org/entity/Q1985786"
-                    if is_julian
-                    else "http://www.wikidata.org/entity/Q1985727",
+                    "calendarmodel": (
+                        "http://www.wikidata.org/entity/Q1985786"
+                        if is_julian
+                        else "http://www.wikidata.org/entity/Q1985727"
+                    ),
                 },
             }
         return None
@@ -321,8 +337,10 @@ class BaseParser(object):
 
         Returns None otherwise
         """
+
         def str_amount(amount):
             return f"+{amount}" if amount >= 0 else f"{amount}"
+
         quantity_match = re.match(r"^([\+\-]{0,1}\d+(\.\d+){0,1})(U(\d+)){0,1}$", v)
         if quantity_match:
             amount = Decimal(quantity_match.group(1))
@@ -332,7 +350,6 @@ class BaseParser(object):
                 "value": {
                     "amount": str_amount(amount),
                     "unit": unit if unit else "1",
-
                 },
             }
 
@@ -341,7 +358,7 @@ class BaseParser(object):
             r"\[([\+\-]{0,1}\d+(\.\d+){0,1}),\s{0,1}"
             r"([\+\-]{0,1}\d+(\.\d+){0,1})\]"
             r"(U(\d+)){0,1}$",
-            v
+            v,
         )
         if bounds_match:
             value = Decimal(bounds_match.group(1))
@@ -359,7 +376,8 @@ class BaseParser(object):
             }
 
         quantity_error_match = re.match(
-            r"^([\+\-]{0,1}\d+(\.\d+){0,1})\s*~\s*([\+\-]{0,1}\d+(\.\d+){0,1})(U(\d+)){0,1}$", v
+            r"^([\+\-]{0,1}\d+(\.\d+){0,1})\s*~\s*([\+\-]{0,1}\d+(\.\d+){0,1})(U(\d+)){0,1}$",
+            v,
         )
         if quantity_error_match:
             value = Decimal(quantity_error_match.group(1))
@@ -382,9 +400,9 @@ class BaseParser(object):
         Returns None otherwise
         """
         v = v.strip()
-        v = v.replace('“', '"').replace('”', '"') # fixes weird double-quotes
+        v = v.replace("“", '"').replace("”", '"')  # fixes weird double-quotes
         for fn in [
-            self.parse_value_somevalue_novalue, 
+            self.parse_value_somevalue_novalue,
             self.parse_value_entity,
             self.parse_value_url,
             self.parse_value_commons_media_file,

--- a/src/core/parsers/csv.py
+++ b/src/core/parsers/csv.py
@@ -70,7 +70,10 @@ class CSVCommandParser(BaseParser):
             elif header_value.startswith("qal"):
                 # Our header indicates that this column represents a qualifier
                 # We add the cell value to the last command created
-                qualifier = {"property": header_value.replace("qal", "P"), "value": current_value}
+                qualifier = {
+                    "property": header_value.replace("qal", "P"),
+                    "value": current_value,
+                }
                 qualifiers = current_command.get("qualifiers", [])
                 qualifiers.append(qualifier)
                 current_command["qualifiers"] = qualifiers
@@ -122,7 +125,12 @@ class CSVCommandParser(BaseParser):
                         current_action = action
                         current_what = _type
                         lang = header_value[1:]
-                        current_command = {"action": action, "what": current_what, "item": qid, "value": current_value}
+                        current_command = {
+                            "action": action,
+                            "what": current_what,
+                            "item": qid,
+                            "value": current_value,
+                        }
                         if current_what == "sitelink":
                             current_command["site"] = lang
                         else:
@@ -130,7 +138,9 @@ class CSVCommandParser(BaseParser):
                         # Code expects aliases to be a list of alias, like in v1
                         if current_command["what"] == "alias":
                             current_command["value"]["type"] = "aliases"
-                            current_command["value"]["value"] = [current_command["value"]["value"]]
+                            current_command["value"]["value"] = [
+                                current_command["value"]["value"]
+                            ]
 
                     commands.append(current_command)
 
@@ -160,7 +170,9 @@ class CSVCommandParser(BaseParser):
                     raise ParserException("A valid property must precede a comment")
                 elif clean_cell.startswith("qal"):
                     raise ParserException("A valid property must precede a qualifier")
-                elif (clean_cell[0] == "s" or clean_cell[0] == "S") and re.match("^[Ss]\\d+$", clean_cell):
+                elif (clean_cell[0] == "s" or clean_cell[0] == "S") and re.match(
+                    "^[Ss]\\d+$", clean_cell
+                ):
                     raise ParserException("A valid property must precede a source")
         return True
 

--- a/src/core/parsers/v1.py
+++ b/src/core/parsers/v1.py
@@ -62,9 +62,16 @@ class V1CommandParser(BaseParser):
                 if item1_id > item2_id:
                     # Always merge into older item
                     item1, item2 = item2, item1
-                return {"action": "merge", "type": "item", "item1": item1, "item2": item2}
+                return {
+                    "action": "merge",
+                    "type": "item",
+                    "item1": item1,
+                    "item2": item2,
+                }
             except ValueError:
-                raise ParserException(f"MERGE items wrong format item1=[{item1}] item2=[{item2}]")
+                raise ParserException(
+                    f"MERGE items wrong format item1=[{item1}] item2=[{item2}]"
+                )
 
     def parse_remove_qualifier(self, elements):
         # We are blocking with 6 columns, but, in the future,
@@ -105,13 +112,22 @@ class V1CommandParser(BaseParser):
             _id = elements[1].strip()
             _split = _id.split("$")
             if len(_split) != 2:
-                raise ParserException("ITEM ID format in REMOVE STATEMENT must be Q1234$UUID")
-            return {"action": "remove", "what": "statement", "id": _id, "entity": {"id": _split[0]}}
+                raise ParserException(
+                    "ITEM ID format in REMOVE STATEMENT must be Q1234$UUID"
+                )
+            return {
+                "action": "remove",
+                "what": "statement",
+                "id": _id,
+                "entity": {"id": _split[0]},
+            }
 
     def parse_statement(self, elements, first_command):
         llen = len(elements)
         if llen < 3:
-            raise ParserException("STATEMENT must contain at least entity, property and value")
+            raise ParserException(
+                "STATEMENT must contain at least entity, property and value"
+            )
 
         if first_command[0] == "-":
             action = "remove"
@@ -138,7 +154,13 @@ class V1CommandParser(BaseParser):
                 if not valias or valias["type"] != "string":
                     raise ParserException("alias must be a string instance")
                 aliases.append(valias["value"])
-            data = {"action": action, "what": "alias", "language": lang, "item": entity, "value": {"type": "aliases", "value": aliases}}
+            data = {
+                "action": action,
+                "what": "alias",
+                "language": lang,
+                "item": entity,
+                "value": {"type": "aliases", "value": aliases},
+            }
 
         elif llen == 3 and elements[1][0] in ["L", "D", "S"]:
             # We are adding / removing a LABEL, ALIAS, DESCRIPTION or SITELINK to our property
@@ -209,7 +231,9 @@ class V1CommandParser(BaseParser):
                     if not self.is_valid_source_id(key):
                         raise ParserException(f"Invalid source {key}")
 
-                    current_reference_block.append({"property": "P" + key[1:], "value": value})
+                    current_reference_block.append(
+                        {"property": "P" + key[1:], "value": value}
+                    )
                     has_references = True
 
                 index += 2

--- a/src/core/tests/test_api.py
+++ b/src/core/tests/test_api.py
@@ -150,13 +150,13 @@ class ApiMocker:
     @classmethod
     def item_empty(cls, mocker, item_id):
         EMPTY_ITEM = {
-          "type": "item",
-          "labels": {},
-          "descriptions": {},
-          "aliases": {},
-          "statements": {},
-          "sitelinks": {},
-          "id": item_id,
+            "type": "item",
+            "labels": {},
+            "descriptions": {},
+            "aliases": {},
+            "statements": {},
+            "sitelinks": {},
+            "id": item_id,
         }
         mocker.get(
             cls.wikibase_url(f"/entities/items/{item_id}"),
@@ -198,7 +198,9 @@ class ApiMocker:
 
     @classmethod
     def add_statement_successful(cls, mocker, item_id, response_json=None):
-        response_json = response_json if response_json else {"id": f"{item_id}$somestuff"}
+        response_json = (
+            response_json if response_json else {"id": f"{item_id}$somestuff"}
+        )
         mocker.patch(
             cls.wikibase_url(f"/entities/items/{item_id}"),
             json=response_json,
@@ -241,11 +243,15 @@ class ApiMocker:
     def sitelink_success(cls, mocker, item_id, sitelink, value):
         mocker.patch(
             cls.wikibase_url(f"/entities/items/{item_id}"),
-            json={"sitelinks": {sitelink: {
-                "title": value,
-                "badges": [],
-                "url": "ignored",
-            }}},
+            json={
+                "sitelinks": {
+                    sitelink: {
+                        "title": value,
+                        "badges": [],
+                        "url": "ignored",
+                    }
+                }
+            },
             status_code=200,
         )
 
@@ -466,19 +472,28 @@ class ClientTests(TestCase):
 
     @requests_mock.Mocker()
     def test_get_labels(self, mocker):
-        labels = {"Q123": {
-            "en": "English label",
-            "pt": "Portuguese label",
-        }}
+        labels = {
+            "Q123": {
+                "en": "English label",
+                "pt": "Portuguese label",
+            }
+        }
         client = self.api_client()
         ApiMocker.labels(mocker, client, labels)
         returned_labels = client.get_multiple_labels(["Q123"], "pt")
-        self.assertEqual(returned_labels, {
-            "entities": {"Q123": {"labels": {
-                "en": {"language": "en", "value": "English label"},
-                "pt": {"language": "pt", "value": "Portuguese label"},
-            }
-        }}})
+        self.assertEqual(
+            returned_labels,
+            {
+                "entities": {
+                    "Q123": {
+                        "labels": {
+                            "en": {"language": "en", "value": "English label"},
+                            "pt": {"language": "pt", "value": "Portuguese label"},
+                        }
+                    }
+                }
+            },
+        )
 
     @requests_mock.Mocker()
     def test_verify_value_type(self, mocker):
@@ -649,6 +664,7 @@ class ClientTests(TestCase):
         }
         self.assertEqual(client.headers(), headers)
 
+
 class TestBatchCommand(TestCase):
     def login_user_and_get_token(self, username):
         """
@@ -668,7 +684,9 @@ class TestBatchCommand(TestCase):
         client = Client.from_user(user)
         payload = BatchCommand().api_payload(client)
         self.assertEqual(payload, {})
-        payload = BatchCommand(operation=BatchCommand.Operation.CREATE_ITEM).api_payload(client)
+        payload = BatchCommand(
+            operation=BatchCommand.Operation.CREATE_ITEM
+        ).api_payload(client)
         self.assertEqual(payload, {"item": {}})
 
     @override_settings(TOOLFORGE_TOOL_NAME="qs-dev")
@@ -707,7 +725,9 @@ class TestBatchCommand(TestCase):
     def test_send_create_property(self, mocker):
         ApiMocker.is_autoconfirmed(mocker)
         user, client = self.login_user_and_get_token("user")
-        batch = V1CommandParser().parse("b", "u", "CREATE_PROPERTY|wikibase-item||LAST|P1|Q1")
+        batch = V1CommandParser().parse(
+            "b", "u", "CREATE_PROPERTY|wikibase-item||LAST|P1|Q1"
+        )
         batch.save_batch_and_preview_commands()
         cmd: BatchCommand = batch.commands()[0]
         cmd.run(client)

--- a/src/core/tests/test_base_parser.py
+++ b/src/core/tests/test_base_parser.py
@@ -177,18 +177,31 @@ class TestBaseParser(TestCase):
 
     def test_parse_value_somevalue_novalue(self):
         parser = BaseParser()
-        self.assertEqual(parser.parse_value("somevalue"), {"value": "somevalue", "type": "somevalue"})
-        self.assertEqual(parser.parse_value("novalue"), {"value": "novalue", "type": "novalue"})
+        self.assertEqual(
+            parser.parse_value("somevalue"), {"value": "somevalue", "type": "somevalue"}
+        )
+        self.assertEqual(
+            parser.parse_value("novalue"), {"value": "novalue", "type": "novalue"}
+        )
 
     def test_parse_value_item(self):
         parser = BaseParser()
-        self.assertEqual(parser.parse_value("LAST"), {"type": "wikibase-entityid", "value": "LAST"})
-        self.assertEqual(parser.parse_value("Q1233"), {"type": "wikibase-entityid", "value": "Q1233"})
-        self.assertEqual(parser.parse_value("M1233"), {"type": "wikibase-entityid", "value": "M1233"})
+        self.assertEqual(
+            parser.parse_value("LAST"), {"type": "wikibase-entityid", "value": "LAST"}
+        )
+        self.assertEqual(
+            parser.parse_value("Q1233"), {"type": "wikibase-entityid", "value": "Q1233"}
+        )
+        self.assertEqual(
+            parser.parse_value("M1233"), {"type": "wikibase-entityid", "value": "M1233"}
+        )
 
     def test_parse_value_string(self):
         parser = BaseParser()
-        self.assertEqual(parser.parse_value('"this is a string"'), {"type": "string", "value": "this is a string"})
+        self.assertEqual(
+            parser.parse_value('"this is a string"'),
+            {"type": "string", "value": "this is a string"},
+        )
         self.assertIsNone(parser.parse_value("not a string"))
         self.assertIsNone(parser.parse_value("'this is a string'"))
 
@@ -243,7 +256,9 @@ class TestBaseParser(TestCase):
             },
         )
         self.assertEqual(
-            parser.parse_value('"""\'Girl Reading\' by Mary Colman Wheeler, El Paso Museum of Art.JPG"""'),
+            parser.parse_value(
+                '"""\'Girl Reading\' by Mary Colman Wheeler, El Paso Museum of Art.JPG"""'
+            ),
             {
                 "type": "string",
                 "value": "'Girl Reading' by Mary Colman Wheeler, El Paso Museum of Art.JPG",
@@ -321,7 +336,12 @@ class TestBaseParser(TestCase):
 
         ret = {
             "type": "quantity",
-            "value": {"amount": "+9", "upperBound": "+9.1", "lowerBound": "+8.9", "unit": "1"},
+            "value": {
+                "amount": "+9",
+                "upperBound": "+9.1",
+                "lowerBound": "+8.9",
+                "unit": "1",
+            },
         }
         self.assertEqual(parser.parse_value("9~0.1"), ret)
         self.assertEqual(parser.parse_value("9[8.9, 9.1]"), ret)
@@ -331,17 +351,27 @@ class TestBaseParser(TestCase):
 
         ret = {"type": "quantity", "value": {"amount": "+12.8", "unit": "11573"}}
         self.assertEqual(parser.parse_value("12.8U11573"), ret)
-        
+
         ret = {
             "type": "quantity",
-            "value": {"amount": "+9.6", "upperBound": "+9.7", "lowerBound": "+9.5", "unit": "11573"},
+            "value": {
+                "amount": "+9.6",
+                "upperBound": "+9.7",
+                "lowerBound": "+9.5",
+                "unit": "11573",
+            },
         }
         self.assertEqual(parser.parse_value("9.6~0.1U11573"), ret)
         self.assertEqual(parser.parse_value("9.6[9.5, 9.7]U11573"), ret)
 
         ret = {
             "type": "quantity",
-            "value": {"amount": "+9.123", "upperBound": "+9.246", "lowerBound": "+9.000", "unit": "1"},
+            "value": {
+                "amount": "+9.123",
+                "upperBound": "+9.246",
+                "lowerBound": "+9.000",
+                "unit": "1",
+            },
         }
         self.assertEqual(parser.parse_value("9.123~0.123"), ret)
         self.assertEqual(parser.parse_value("9.123[9.000,9.246]"), ret)

--- a/src/core/tests/test_batch.py
+++ b/src/core/tests/test_batch.py
@@ -137,7 +137,9 @@ class TestBatch(TestCase):
         self.assertFalse(batch.is_stopped)
         batch.stop()
         self.assertTrue(batch.is_stopped)
-        self.assertTrue(batch.message.startswith("Batch stopped processing by owner at"))
+        self.assertTrue(
+            batch.message.startswith("Batch stopped processing by owner at")
+        )
 
     def test_batch_restart(self):
         batch = Batch.objects.create(name="teste", status=Batch.STATUS_BLOCKED)
@@ -156,6 +158,7 @@ class TestBatch(TestCase):
         batch.restart()
         self.assertTrue(batch.is_initial)
         self.assertTrue(batch.message.startswith("Batch restarted by owner"))
+
 
 class TestV1Batch(TestCase):
     def test_v1_correct_create_command(self):
@@ -197,7 +200,9 @@ class TestV1Batch(TestCase):
         batch = v1.parse("b", "u", "-Q1234|P5|Q31")
         batch.save_batch_and_preview_commands()
         cmd = batch.commands()[0]
-        self.assertEqual(cmd.operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE)
+        self.assertEqual(
+            cmd.operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE
+        )
         self.assertEqual(cmd.entity_id(), "Q1234")
         self.assertEqual(cmd.prop, "P5")
         self.assertEqual(cmd.statement_api_value, {"type": "value", "content": "Q31"})
@@ -207,10 +212,14 @@ class TestV1Batch(TestCase):
         batch = v1.parse("b", "u", """-Q1234|P5|"my string" """)
         batch.save_batch_and_preview_commands()
         cmd = batch.commands()[0]
-        self.assertEqual(cmd.operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE)
+        self.assertEqual(
+            cmd.operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE
+        )
         self.assertEqual(cmd.entity_id(), "Q1234")
         self.assertEqual(cmd.prop, "P5")
-        self.assertEqual(cmd.statement_api_value, {"type": "value", "content": "my string"})
+        self.assertEqual(
+            cmd.statement_api_value, {"type": "value", "content": "my string"}
+        )
 
     def test_user_summary(self):
         v1 = V1CommandParser()
@@ -226,9 +235,15 @@ class TestV1Batch(TestCase):
         batch.save_batch_and_preview_commands()
         batch_id = batch.id
         cmd = BatchCommand.objects.get(batch=batch, index=0)
-        self.assertEqual(cmd.edit_summary(), f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]: my comment")
+        self.assertEqual(
+            cmd.edit_summary(),
+            f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]: my comment",
+        )
         cmd = BatchCommand.objects.get(batch=batch, index=1)
-        self.assertEqual(cmd.edit_summary(), f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]")
+        self.assertEqual(
+            cmd.edit_summary(),
+            f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]",
+        )
 
     def test_set_sitelink(self):
         v1 = V1CommandParser()
@@ -276,9 +291,10 @@ class TestV1Batch(TestCase):
         self.assertEqual(cmd.operation, BatchCommand.Operation.REMOVE_QUALIFIER)
         self.assertEqual(cmd.entity_id(), "Q1234")
         self.assertEqual(len(cmd.references()), 0)
-        self.assertEqual(cmd.qualifiers_for_api(), [
-            {"property": {"id": "P3"}, "value": {"type": "value", "content": "Q4"}}
-        ])
+        self.assertEqual(
+            cmd.qualifiers_for_api(),
+            [{"property": {"id": "P3"}, "value": {"type": "value", "content": "Q4"}}],
+        )
 
     def test_remove_reference(self):
         v1 = V1CommandParser()
@@ -288,11 +304,19 @@ class TestV1Batch(TestCase):
         self.assertEqual(cmd.operation, BatchCommand.Operation.REMOVE_REFERENCE)
         self.assertEqual(cmd.entity_id(), "Q1234")
         self.assertEqual(len(cmd.qualifiers()), 0)
-        self.assertEqual(cmd.references_for_api(), [
-            {"parts":  [
-                {"property": {"id": "P3"}, "value": {"type": "value", "content": "Q4"}}
-            ]}
-        ])
+        self.assertEqual(
+            cmd.references_for_api(),
+            [
+                {
+                    "parts": [
+                        {
+                            "property": {"id": "P3"},
+                            "value": {"type": "value", "content": "Q4"},
+                        }
+                    ]
+                }
+            ],
+        )
 
 
 class TestCSVBatch(TestCase):
@@ -502,7 +526,10 @@ Q4115189,"Patterns, Predictors, and Outcome"
             {
                 "action": "add",
                 "item": "Q4115189",
-                "value": {"type": "string", "value": "Patterns, Predictors, and Outcome"},
+                "value": {
+                    "type": "string",
+                    "value": "Patterns, Predictors, and Outcome",
+                },
                 "what": "label",
                 "language": "en",
             },
@@ -541,7 +568,10 @@ Q411518,"Patterns, Predictors, and Outcome and Questions"
             {
                 "action": "add",
                 "item": "Q411518",
-                "value": {"type": "aliases", "value": ["Patterns, Predictors, and Outcome and Questions"]},
+                "value": {
+                    "type": "aliases",
+                    "value": ["Patterns, Predictors, and Outcome and Questions"],
+                },
                 "what": "alias",
                 "language": "pt",
             },
@@ -580,7 +610,10 @@ Q411518,"Patterns, Predictors, and Outcome and Descriptions"
             {
                 "action": "add",
                 "item": "Q411518",
-                "value": {"type": "string", "value": "Patterns, Predictors, and Outcome and Descriptions"},
+                "value": {
+                    "type": "string",
+                    "value": "Patterns, Predictors, and Outcome and Descriptions",
+                },
                 "what": "description",
                 "language": "pt",
             },
@@ -684,13 +717,26 @@ Q4115189,Douglas Adams,author,Douglas Noël Adams,Q5,Q36180,Q6581097,Q463035,\"\
                 "property": "P735",
                 "value": {"type": "wikibase-entityid", "value": "Q463035"},
                 "what": "statement",
-                "qualifiers": [{"property": "P1545", "value": {"type": "string", "value": "1"}}],
+                "qualifiers": [
+                    {"property": "P1545", "value": {"type": "string", "value": "1"}}
+                ],
                 "references": [
                     [
-                        {"property": "P248", "value": {"type": "wikibase-entityid", "value": "Q54919"}},
-                        {"property": "P214", "value": {"type": "string", "value": "113230702"}},
+                        {
+                            "property": "P248",
+                            "value": {"type": "wikibase-entityid", "value": "Q54919"},
+                        },
+                        {
+                            "property": "P214",
+                            "value": {"type": "string", "value": "113230702"},
+                        },
                     ],
-                    [{"property": "P143", "value": {"type": "wikibase-entityid", "value": "Q328"}}],
+                    [
+                        {
+                            "property": "P143",
+                            "value": {"type": "wikibase-entityid", "value": "Q328"},
+                        }
+                    ],
                 ],
             },
         )
@@ -727,9 +773,15 @@ Q4115189,Q5,
         batch.save_batch_and_preview_commands()
         batch_id = batch.id
         cmd = BatchCommand.objects.get(batch=batch, index=0)
-        self.assertEqual(cmd.edit_summary(), f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]: my comment")
+        self.assertEqual(
+            cmd.edit_summary(),
+            f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]: my comment",
+        )
         cmd = BatchCommand.objects.get(batch=batch, index=1)
-        self.assertEqual(cmd.edit_summary(), f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]")
+        self.assertEqual(
+            cmd.edit_summary(),
+            f"[[:toollabs:abcdef/batch/{batch_id}|batch #{batch_id}]]",
+        )
 
     @override_settings(TOOLFORGE_TOOL_NAME=None)
     def test_edit_summary_without_editgroups(self):
@@ -752,7 +804,9 @@ Q4115189,Q5,Q6"""
         batch = par.parse("b", "u", COMMAND)
         batch.save_batch_and_preview_commands()
         cmd = batch.commands()[1]
-        self.assertEqual(cmd.operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE)
+        self.assertEqual(
+            cmd.operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE
+        )
         self.assertEqual(cmd.entity_id(), "Q4115189")
         self.assertEqual(cmd.prop, "P31")
         self.assertEqual(cmd.statement_api_value, {"type": "value", "content": "Q6"})

--- a/src/core/tests/test_batch_command_methods.py
+++ b/src/core/tests/test_batch_command_methods.py
@@ -213,8 +213,10 @@ class TestBatchCommand(TestCase):
         ApiMocker.is_autoconfirmed(mocker)
         ApiMocker.item_empty(mocker, "Q1234")
         ApiMocker.item_empty(mocker, "Q333")
-        batch = self.parse("""Q1234|P1|Q2
-        Q333|P3|12|P5|100""")
+        batch = self.parse(
+            """Q1234|P1|Q2
+        Q333|P3|12|P5|100"""
+        )
         commands = batch.commands()
         client = Client.from_username("user")
         self.assertEqual(len(commands), 2)
@@ -246,11 +248,19 @@ class TestBatchCommand(TestCase):
                         "value": [
                             {
                                 "property": {"id": "P3"},
-                                "value": {"type": "value", "content": {"amount": "+12", "unit": "1"}},
-                                "qualifiers": [{
-                                    "property": {"id": "P5"},
-                                    "value": {"type": "value", "content": {"amount": "+100", "unit": "1"}},
-                                }],
+                                "value": {
+                                    "type": "value",
+                                    "content": {"amount": "+12", "unit": "1"},
+                                },
+                                "qualifiers": [
+                                    {
+                                        "property": {"id": "P5"},
+                                        "value": {
+                                            "type": "value",
+                                            "content": {"amount": "+100", "unit": "1"},
+                                        },
+                                    }
+                                ],
                             }
                         ],
                     }

--- a/src/core/tests/test_batch_processing.py
+++ b/src/core/tests/test_batch_processing.py
@@ -193,7 +193,9 @@ class ProcessingTests(TestCase):
 
         ApiMocker.add_statement_failed_server(mocker, "Q2")
         v1 = V1CommandParser()
-        batch = v1.parse("Should block", "user", "Q1|P5|123||Q2|P5|123||Q1|P5|123||Q1|P5|123")
+        batch = v1.parse(
+            "Should block", "user", "Q1|P5|123||Q2|P5|123||Q1|P5|123||Q1|P5|123"
+        )
         batch.block_on_errors = True
         batch.save_batch_and_preview_commands()
         batch.run()
@@ -223,7 +225,9 @@ class ProcessingTests(TestCase):
         commands = batch.commands()
         self.assertEqual(commands[0].operation, BatchCommand.Operation.CREATE_ITEM)
         self.assertEqual(commands[0].status, BatchCommand.STATUS_ERROR)
-        self.assertTrue("The server failed to process the request" in commands[0].message)
+        self.assertTrue(
+            "The server failed to process the request" in commands[0].message
+        )
         self.assertEqual(commands[1].status, BatchCommand.STATUS_ERROR)
         self.assertEqual(commands[1].error, BatchCommand.Error.LAST_NOT_EVALUATED)
         self.assertEqual(commands[1].message, "LAST could not be evaluated.")
@@ -248,7 +252,9 @@ class ProcessingTests(TestCase):
         commands = batch.commands()
         self.assertEqual(commands[0].operation, BatchCommand.Operation.CREATE_ITEM)
         self.assertEqual(commands[0].status, BatchCommand.STATUS_ERROR)
-        self.assertTrue("The server failed to process the request" in commands[0].message)
+        self.assertTrue(
+            "The server failed to process the request" in commands[0].message
+        )
         self.assertEqual(commands[1].status, BatchCommand.STATUS_INITIAL)
         self.assertEqual(commands[2].status, BatchCommand.STATUS_INITIAL)
         self.assertEqual(commands[3].status, BatchCommand.STATUS_INITIAL)
@@ -294,20 +300,24 @@ class ProcessingTests(TestCase):
         batch.run()
         self.assertEqual(batch.status, Batch.STATUS_DONE)
         commands = batch.commands()
-        self.assertEqual(commands[0].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_ID)
+        self.assertEqual(
+            commands[0].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_ID
+        )
         self.assertEqual(commands[0].status, BatchCommand.STATUS_DONE)
         self.assertEqual(commands[0].response_json, "Statement deleted")
 
     @requests_mock.Mocker()
     def test_remove_statement_by_value_success(self, mocker):
         statements = {
-            "P5": [{
-                "id": "Q1234$abcdefgh-uijkl",
-                "value": {
-                    "type": "value",
-                    "content": "Q12",
-                },
-            }],
+            "P5": [
+                {
+                    "id": "Q1234$abcdefgh-uijkl",
+                    "value": {
+                        "type": "value",
+                        "content": "Q12",
+                    },
+                }
+            ],
         }
         ApiMocker.is_autoconfirmed(mocker)
         ApiMocker.statements(mocker, "Q1234", statements)
@@ -355,20 +365,24 @@ class ProcessingTests(TestCase):
         batch.run()
         self.assertEqual(batch.status, Batch.STATUS_DONE)
         commands = batch.commands()
-        self.assertEqual(commands[0].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE)
+        self.assertEqual(
+            commands[0].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE
+        )
         self.assertEqual(commands[0].status, BatchCommand.STATUS_ERROR)
         self.assertEqual(commands[0].error, BatchCommand.Error.NO_STATEMENTS_PROPERTY)
 
     @requests_mock.Mocker()
     def test_remove_statement_by_value_fail_no_statements_value(self, mocker):
         statements = {
-            "P5": [{
-                "id": "Q1234$abcdefgh-uijkl",
-                "value": {
-                    "type": "value",
-                    "content": "this is my string",
-                },
-            }],
+            "P5": [
+                {
+                    "id": "Q1234$abcdefgh-uijkl",
+                    "value": {
+                        "type": "value",
+                        "content": "this is my string",
+                    },
+                }
+            ],
         }
         ApiMocker.is_autoconfirmed(mocker)
         ApiMocker.statements(mocker, "Q1234", statements)
@@ -376,7 +390,9 @@ class ProcessingTests(TestCase):
         batch.run()
         self.assertEqual(batch.status, Batch.STATUS_DONE)
         commands = batch.commands()
-        self.assertEqual(commands[0].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE)
+        self.assertEqual(
+            commands[0].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE
+        )
         self.assertEqual(commands[0].status, BatchCommand.STATUS_ERROR)
         self.assertEqual(commands[0].error, BatchCommand.Error.NO_STATEMENTS_VALUE)
 
@@ -411,28 +427,30 @@ class ProcessingTests(TestCase):
         ApiMocker.wikidata_property_data_types(mocker)
         ApiMocker.is_autoconfirmed(mocker)
         ApiMocker.property_data_type(mocker, "P89982", "quantity")
-        ApiMocker.statements(mocker, "Q1", {
-        "P89982": [
-          {
-            "id": "Q208235$79D23941-64B1-4260-A962-8AB10E84B2C2",
-            "rank": "normal",
-            "qualifiers": [],
-            "references": [],
-            "property": {
-              "id": "P89982",
-              "data_type": "quantity"
+        ApiMocker.statements(
+            mocker,
+            "Q1",
+            {
+                "P89982": [
+                    {
+                        "id": "Q208235$79D23941-64B1-4260-A962-8AB10E84B2C2",
+                        "rank": "normal",
+                        "qualifiers": [],
+                        "references": [],
+                        "property": {"id": "P89982", "data_type": "quantity"},
+                        "value": {
+                            "type": "value",
+                            "content": {
+                                "amount": "+30",
+                                "unit": "http://test.wikidata.org/entity/Q208592",
+                                "upperBound": "+40",
+                                "lowerBound": "+10",
+                            },
+                        },
+                    }
+                ]
             },
-            "value": {
-              "type": "value",
-              "content": {
-                "amount": "+30",
-                "unit": "http://test.wikidata.org/entity/Q208592",
-                "upperBound": "+40",
-                "lowerBound": "+10"
-              }
-            }
-          }
-        ]})
+        )
         ApiMocker.patch_item_successful(mocker, "Q1", {})
         batch = self.parse("-Q1|P89982|30[10,40]U208592")
         batch.run()
@@ -452,19 +470,30 @@ class ProcessingTests(TestCase):
         ApiMocker.item_empty(mocker, "Q7")
         ApiMocker.property_data_type(mocker, "P5", "quantity")
         ApiMocker.sitelink_invalid(mocker, "Q1234", "ptwikix")
-        ApiMocker.patch_item_fail(mocker, "Q5", 400,  {"code": "code", "message": "message"})
-        ApiMocker.patch_item_fail(mocker, "Q7", 500,  {"code": "code", "message": "message"})
+        ApiMocker.patch_item_fail(
+            mocker, "Q5", 400, {"code": "code", "message": "message"}
+        )
+        ApiMocker.patch_item_fail(
+            mocker, "Q7", 500, {"code": "code", "message": "message"}
+        )
         ApiMocker.statements(mocker, "Q9", {})
-        ApiMocker.statements(mocker, "Q11", {
-            "P5": [{
-                "id": "Q1234$abcdefgh-uijkl",
-                "value": {
-                    "type": "value",
-                    "content": {"amount": "+32", "unit": "1"},
-                },
-            }],
-        })
-        batch = self.parse("""
+        ApiMocker.statements(
+            mocker,
+            "Q11",
+            {
+                "P5": [
+                    {
+                        "id": "Q1234$abcdefgh-uijkl",
+                        "value": {
+                            "type": "value",
+                            "content": {"amount": "+32", "unit": "1"},
+                        },
+                    }
+                ],
+            },
+        )
+        batch = self.parse(
+            """
         CREATE_PROPERTY|url
         Q1234|P5|12
         Q1234|Sptwikix|"Cool article"
@@ -472,7 +501,8 @@ class ProcessingTests(TestCase):
         Q7|P5|321
         -Q9|P5|123
         -Q11|P5|123
-        """)
+        """
+        )
         batch.combine_commands = True
         batch.run()
         self.assertEqual(batch.status, Batch.STATUS_DONE)
@@ -487,9 +517,13 @@ class ProcessingTests(TestCase):
         self.assertEqual(commands[3].error, BatchCommand.Error.API_USER_ERROR)
         self.assertEqual(commands[4].operation, BatchCommand.Operation.SET_STATEMENT)
         self.assertEqual(commands[4].error, BatchCommand.Error.API_SERVER_ERROR)
-        self.assertEqual(commands[5].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE)
+        self.assertEqual(
+            commands[5].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE
+        )
         self.assertEqual(commands[5].error, BatchCommand.Error.NO_STATEMENTS_PROPERTY)
-        self.assertEqual(commands[6].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE)
+        self.assertEqual(
+            commands[6].operation, BatchCommand.Operation.REMOVE_STATEMENT_BY_VALUE
+        )
         self.assertEqual(commands[6].error, BatchCommand.Error.NO_STATEMENTS_VALUE)
         self.assertEqual(len(commands), 7)
         for command in commands:
@@ -505,11 +539,13 @@ class ProcessingTests(TestCase):
         ApiMocker.property_data_type(mocker, "P1", "quantity")
         ApiMocker.patch_item_successful(mocker, "Q1", {})
         ApiMocker.patch_item_successful(mocker, "Q2", {})
-        batch = self.parse("""
+        batch = self.parse(
+            """
         CREATE
         LAST|P1|12
         Q2|P1|15
-        """)
+        """
+        )
         batch.combine_commands = True
         commands = batch.commands()
         client = ApiClient.from_username(batch.user)
@@ -530,7 +566,7 @@ class ProcessingTests(TestCase):
         self.assertEqual(commands[0].display_label, None)
         self.assertEqual(commands[1].display_label, None)
         self.assertEqual(commands[2].display_label, "en2")
-        batch.run() # -> load Q1 into commands[0] and commands[1]
+        batch.run()  # -> load Q1 into commands[0] and commands[1]
         commands = batch.commands()
         BatchCommand.load_labels(client, commands, "pt")
         self.assertEqual(commands[0].display_label, "pt1")
@@ -573,7 +609,10 @@ class ProcessingTests(TestCase):
                                     "hash": "i_am_ahash",
                                     "parts": [
                                         {
-                                            "property": {"id": "P93", "data_type": "url"},
+                                            "property": {
+                                                "id": "P93",
+                                                "data_type": "url",
+                                            },
                                             "value": {
                                                 "type": "value",
                                                 "content": "https://kernel.org/",
@@ -591,14 +630,16 @@ class ProcessingTests(TestCase):
         ApiMocker.is_autoconfirmed(mocker)
         ApiMocker.property_data_type(mocker, "P5", "wikibase-item")
         ApiMocker.patch_item_successful(mocker, "Q1", {})
-        batch = self.parse("""
+        batch = self.parse(
+            """
         REMOVE_QUAL|Q1|P5|Q12|P123|123
         REMOVE_QUAL|Q1|P5|Q999|P65|84
         REMOVE_QUAL|Q1|P5|Q12|P65|84
         REMOVE_REF|Q1|P5|Q12|S93|"https://kernel.xyz"
         REMOVE_REF|Q1|P5|Q999|S93|"https://kernel.org/"
         REMOVE_REF|Q1|P5|Q12|S93|"https://kernel.org/"
-        """)
+        """
+        )
         commands = batch.commands()
         batch.run()
         # qualifiers
@@ -636,10 +677,12 @@ class ProcessingTests(TestCase):
         commands = batch.commands()
         batch.run()
         self.assertEqual(batch.status, Batch.STATUS_DONE)
-        self.assertEqual(commands[0].response_json, {}) # no API connection
-        self.assertEqual(commands[1].response_json, {}) # no API connection
-        self.assertEqual(commands[2].response_json, {}) # no API connection
-        self.assertEqual(commands[3].response_json, {"id": "Q123"}) # created: API connection
+        self.assertEqual(commands[0].response_json, {})  # no API connection
+        self.assertEqual(commands[1].response_json, {})  # no API connection
+        self.assertEqual(commands[2].response_json, {})  # no API connection
+        self.assertEqual(
+            commands[3].response_json, {"id": "Q123"}
+        )  # created: API connection
         self.assertEqual(len(commands), 4)
         for command in commands:
             self.assertEqual(command.status, BatchCommand.STATUS_DONE)
@@ -653,10 +696,18 @@ class ProcessingTests(TestCase):
         batch.run()
         commands = batch.commands()
         self.assertEqual(batch.status, Batch.STATUS_DONE)
-        self.assertEqual(commands[0].response_json, {"id": "Q123"}) # with API connection
-        self.assertEqual(commands[1].response_json, {"id": "Q123$abcdef"}) # with API connection
-        self.assertEqual(commands[2].response_json, {"id": "Q123$abcdef"}) # with API connection
-        self.assertEqual(commands[3].response_json, {"id": "Q123$abcdef"}) # with API connection
+        self.assertEqual(
+            commands[0].response_json, {"id": "Q123"}
+        )  # with API connection
+        self.assertEqual(
+            commands[1].response_json, {"id": "Q123$abcdef"}
+        )  # with API connection
+        self.assertEqual(
+            commands[2].response_json, {"id": "Q123$abcdef"}
+        )  # with API connection
+        self.assertEqual(
+            commands[3].response_json, {"id": "Q123$abcdef"}
+        )  # with API connection
         self.assertEqual(len(commands), 4)
         for command in commands:
             self.assertEqual(command.status, BatchCommand.STATUS_DONE)

--- a/src/core/tests/test_csv_parser.py
+++ b/src/core/tests/test_csv_parser.py
@@ -22,7 +22,21 @@ class TestCSVParser(TestCase):
         self.assertTrue(parser.check_header(["qid", "P31", "Len", "Den", "P18"]))
         self.assertTrue(
             parser.check_header(
-                ["qid", "Len", "Den", "Aen", "P31", "-P31", "P21", "P735", "qal1545", "S248", "s214", "S143", "Senwiki"]
+                [
+                    "qid",
+                    "Len",
+                    "Den",
+                    "Aen",
+                    "P31",
+                    "-P31",
+                    "P21",
+                    "P735",
+                    "qal1545",
+                    "S248",
+                    "s214",
+                    "S143",
+                    "Senwiki",
+                ]
             )
         )
 
@@ -30,28 +44,38 @@ class TestCSVParser(TestCase):
         parser = CSVCommandParser()
         with self.assertRaises(Exception) as context:
             parser.check_header(["", "qid", "P31", "-P31"])
-        self.assertEqual(context.exception.message, "CSV header first element must be qid")
+        self.assertEqual(
+            context.exception.message, "CSV header first element must be qid"
+        )
 
     def test_parse_header_comment_before_property(self):
         parser = CSVCommandParser()
         with self.assertRaises(Exception) as context:
             parser.check_header(["qid", "#", "P31"])
-        self.assertEqual(context.exception.message, "A valid property must precede a comment")
+        self.assertEqual(
+            context.exception.message, "A valid property must precede a comment"
+        )
 
     def test_parse_header_qal_before_property(self):
         parser = CSVCommandParser()
         with self.assertRaises(Exception) as context:
             parser.check_header(["qid", "qal", "P31"])
-        self.assertEqual(context.exception.message, "A valid property must precede a qualifier")
+        self.assertEqual(
+            context.exception.message, "A valid property must precede a qualifier"
+        )
 
     def test_parse_header_source_before_property(self):
         parser = CSVCommandParser()
         with self.assertRaises(Exception) as context:
             parser.check_header(["qid", "S1234", "P31"])
-        self.assertEqual(context.exception.message, "A valid property must precede a source")
+        self.assertEqual(
+            context.exception.message, "A valid property must precede a source"
+        )
         with self.assertRaises(Exception) as context:
             parser.check_header(["qid", "s1234", "P31"])
-        self.assertEqual(context.exception.message, "A valid property must precede a source")
+        self.assertEqual(
+            context.exception.message, "A valid property must precede a source"
+        )
 
     def test_parse_item(self):
         parser = CSVCommandParser()
@@ -162,7 +186,13 @@ class TestCSVParser(TestCase):
     def test_parse_references(self):
         parser = CSVCommandParser()
         parsed_line = parser.parse_line(
-            ["Q22124656", "Q6581097", "comment to claim adding edit", "Q24731821", "+2017-10-04T00:00:00Z/11"],
+            [
+                "Q22124656",
+                "Q6581097",
+                "comment to claim adding edit",
+                "Q24731821",
+                "+2017-10-04T00:00:00Z/11",
+            ],
             ["qid", "P21", "#", "S143", "s813"],
         )
 
@@ -176,7 +206,13 @@ class TestCSVParser(TestCase):
                 "summary": "comment to claim adding edit",
                 "references": [
                     [
-                        {"property": "P143", "value": {"type": "wikibase-entityid", "value": "Q24731821"}},
+                        {
+                            "property": "P143",
+                            "value": {
+                                "type": "wikibase-entityid",
+                                "value": "Q24731821",
+                            },
+                        },
                         {
                             "property": "P813",
                             "value": {
@@ -211,7 +247,13 @@ class TestCSVParser(TestCase):
                 "what": "statement",
                 "summary": "comment to claim adding edit",
                 "qualifiers": [
-                    {"property": "P1545", "value": {'type': 'quantity', 'value': {'amount': '+1', 'unit': '1'}}},
+                    {
+                        "property": "P1545",
+                        "value": {
+                            "type": "quantity",
+                            "value": {"amount": "+1", "unit": "1"},
+                        },
+                    },
                 ],
             }
         ]
@@ -222,7 +264,13 @@ class TestCSVParser(TestCase):
         parser = CSVCommandParser()
 
         parsed_line = parser.parse_line(
-            ["", "Q3305213", "Mona Lisa", "oil painting by Leonardo da Vinci", '"""Mona Lisa - the Louvre.jpg"""'],
+            [
+                "",
+                "Q3305213",
+                "Mona Lisa",
+                "oil painting by Leonardo da Vinci",
+                '"""Mona Lisa - the Louvre.jpg"""',
+            ],
             ["qid", "P31", "Len", "Den", "P18"],
         )
 
@@ -245,7 +293,10 @@ class TestCSVParser(TestCase):
             {
                 "action": "add",
                 "item": "LAST",
-                "value": {"type": "string", "value": "oil painting by Leonardo da Vinci"},
+                "value": {
+                    "type": "string",
+                    "value": "oil painting by Leonardo da Vinci",
+                },
                 "what": "description",
                 "language": "en",
             },
@@ -326,7 +377,9 @@ class TestCSVParser(TestCase):
         )
 
         self.assertEqual(
-            parser.parse_line(["Q4115189", '"""Patterns, Predictors, and Outcome"""'], ["qid", "P370"]),
+            parser.parse_line(
+                ["Q4115189", '"""Patterns, Predictors, and Outcome"""'], ["qid", "P370"]
+            ),
             [
                 {
                     "action": "add",
@@ -344,7 +397,9 @@ class TestCSVParser(TestCase):
     def test_parse_url(self):
         parser = CSVCommandParser()
         self.assertEqual(
-            parser.parse_line(["Q4115189", '"""https://wiki.com.br"""'], ["qid", "P370"]),
+            parser.parse_line(
+                ["Q4115189", '"""https://wiki.com.br"""'], ["qid", "P370"]
+            ),
             [
                 {
                     "action": "add",
@@ -378,7 +433,10 @@ class TestCSVParser(TestCase):
     def test_parse_commons(self):
         parser = CSVCommandParser()
         self.assertEqual(
-            parser.parse_line(["Q4115189", '"""Frans Breydel - A merry company.jpg"""'], ["qid", "P370"]),
+            parser.parse_line(
+                ["Q4115189", '"""Frans Breydel - A merry company.jpg"""'],
+                ["qid", "P370"],
+            ),
             [
                 {
                     "action": "add",
@@ -395,7 +453,10 @@ class TestCSVParser(TestCase):
 
         self.assertEqual(
             parser.parse_line(
-                ["Q4115189", '"""\'Girl Reading\' by Mary Colman Wheeler, El Paso Museum of Art.JPG"""'],
+                [
+                    "Q4115189",
+                    '"""\'Girl Reading\' by Mary Colman Wheeler, El Paso Museum of Art.JPG"""',
+                ],
                 ["qid", "P370"],
             ),
             [
@@ -422,7 +483,10 @@ class TestCSVParser(TestCase):
                     "action": "add",
                     "entity": {"id": "Q4115189", "type": "item"},
                     "property": "P1114",
-                    "value": {"type": "quantity", "value": {"amount": "+10", "unit": "1"}},
+                    "value": {
+                        "type": "quantity",
+                        "value": {"amount": "+10", "unit": "1"},
+                    },
                     "what": "statement",
                 },
             ],
@@ -435,7 +499,10 @@ class TestCSVParser(TestCase):
                     "action": "add",
                     "entity": {"id": "Q4115189", "type": "item"},
                     "property": "P1114",
-                    "value": {"type": "quantity", "value": {"amount": "+20", "unit": "1"}},
+                    "value": {
+                        "type": "quantity",
+                        "value": {"amount": "+20", "unit": "1"},
+                    },
                     "what": "statement",
                 },
             ],
@@ -448,7 +515,10 @@ class TestCSVParser(TestCase):
                     "action": "add",
                     "entity": {"id": "Q4115189", "type": "item"},
                     "property": "P1114",
-                    "value": {"type": "quantity", "value": {"amount": "+3.1415926", "unit": "1"}},
+                    "value": {
+                        "type": "quantity",
+                        "value": {"amount": "+3.1415926", "unit": "1"},
+                    },
                     "what": "statement",
                 },
             ],
@@ -461,7 +531,10 @@ class TestCSVParser(TestCase):
                     "action": "add",
                     "entity": {"id": "Q4115189", "type": "item"},
                     "property": "P1114",
-                    "value": {"type": "quantity", "value": {"amount": "-40", "unit": "1"}},
+                    "value": {
+                        "type": "quantity",
+                        "value": {"amount": "-40", "unit": "1"},
+                    },
                     "what": "statement",
                 },
             ],
@@ -476,7 +549,12 @@ class TestCSVParser(TestCase):
                     "property": "P1114",
                     "value": {
                         "type": "quantity",
-                        "value": {"amount": "-80", "lowerBound": "-81.5", "upperBound": "-78.5", "unit": "1"},
+                        "value": {
+                            "amount": "-80",
+                            "lowerBound": "-81.5",
+                            "upperBound": "-78.5",
+                            "unit": "1",
+                        },
                     },
                     "what": "statement",
                 },
@@ -492,7 +570,12 @@ class TestCSVParser(TestCase):
                     "property": "P1114",
                     "value": {
                         "type": "quantity",
-                        "value": {"amount": "+2.2", "lowerBound": "+1.9", "upperBound": "+2.5", "unit": "1"},
+                        "value": {
+                            "amount": "+2.2",
+                            "lowerBound": "+1.9",
+                            "upperBound": "+2.5",
+                            "unit": "1",
+                        },
                     },
                     "what": "statement",
                 },
@@ -508,7 +591,12 @@ class TestCSVParser(TestCase):
                     "property": "P1114",
                     "value": {
                         "type": "quantity",
-                        "value": {"amount": "+1.2", "lowerBound": "+0.9", "upperBound": "+1.5", "unit": "1"},
+                        "value": {
+                            "amount": "+1.2",
+                            "lowerBound": "+0.9",
+                            "upperBound": "+1.5",
+                            "unit": "1",
+                        },
                     },
                     "what": "statement",
                 },
@@ -549,7 +637,9 @@ class TestCSVParser(TestCase):
 
     def test_parse_alias(self):
         parser = CSVCommandParser()
-        result = parser.parse_line(["Q4115189", "Chacara Santo Antonio"], ["qid", "Apt"])
+        result = parser.parse_line(
+            ["Q4115189", "Chacara Santo Antonio"], ["qid", "Apt"]
+        )
         self.assertEqual(
             result,
             [
@@ -581,14 +671,19 @@ class TestCSVParser(TestCase):
 
     def test_parse_monolingualtext(self):
         parser = CSVCommandParser()
-        result = parser.parse_line(["Q4115189", 'en:"Thats an english, text"'], ["qid", "P31"])
+        result = parser.parse_line(
+            ["Q4115189", 'en:"Thats an english, text"'], ["qid", "P31"]
+        )
         self.assertEqual(
             result,
             [
                 {
                     "action": "add",
                     "entity": {"id": "Q4115189", "type": "item"},
-                    "value": {"type": "monolingualtext", "value": {"language": "en", "text": "Thats an english, text"}},
+                    "value": {
+                        "type": "monolingualtext",
+                        "value": {"language": "en", "text": "Thats an english, text"},
+                    },
                     "what": "statement",
                     "property": "P31",
                 },
@@ -598,7 +693,8 @@ class TestCSVParser(TestCase):
     def test_create(self):
         parser = CSVCommandParser()
         result = parser.parse_line(
-            ["", "Regina Phalange", "fictional character", "Q95074"], ["qid", "Len", "Den", "P31"]
+            ["", "Regina Phalange", "fictional character", "Q95074"],
+            ["qid", "Len", "Den", "P31"],
         )
         self.assertEqual(
             result,

--- a/src/core/tests/test_entity_patching.py
+++ b/src/core/tests/test_entity_patching.py
@@ -162,31 +162,44 @@ class RemoveQualRefTests(TestCase):
         # -----
         create_statement = batch.commands()[0]
         self.assertStmtnCount(entity, "P65", 1)
-        self.assertEqual(entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42")
+        self.assertEqual(
+            entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42"
+        )
         create_statement.update_entity_json(entity)
         self.assertEqual(entity, copy.deepcopy(self.INITIAL))
         # -----
         create_statement = batch.commands()[1]
         self.assertStmtnCount(entity, "P65", 1)
-        self.assertEqual(entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42")
+        self.assertEqual(
+            entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42"
+        )
         create_statement.update_entity_json(entity)
         self.assertStmtnCount(entity, "P65", 2)
-        self.assertEqual(entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42")
+        self.assertEqual(
+            entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42"
+        )
         self.assertRefCount(entity, "P65", 0, 0)
-        self.assertEqual(entity["statements"]["P65"][1]["value"]["content"]["amount"], "+42")
+        self.assertEqual(
+            entity["statements"]["P65"][1]["value"]["content"]["amount"], "+42"
+        )
         self.assertRefCount(entity, "P65", 1, 1)
         # -----
         set_statement2 = batch.commands()[2]
         self.assertStmtnCount(entity, "P65", 2)
         set_statement2.update_entity_json(entity)
         self.assertStmtnCount(entity, "P65", 3)
-        self.assertEqual(entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42")
+        self.assertEqual(
+            entity["statements"]["P65"][0]["value"]["content"]["amount"], "+42"
+        )
         self.assertRefCount(entity, "P65", 0, 0)
-        self.assertEqual(entity["statements"]["P65"][1]["value"]["content"]["amount"], "+42")
+        self.assertEqual(
+            entity["statements"]["P65"][1]["value"]["content"]["amount"], "+42"
+        )
         self.assertRefCount(entity, "P65", 1, 1)
-        self.assertEqual(entity["statements"]["P65"][2]["value"]["content"]["amount"], "-10")
+        self.assertEqual(
+            entity["statements"]["P65"][2]["value"]["content"]["amount"], "-10"
+        )
         self.assertRefCount(entity, "P65", 0, 2)
-
 
     def test_remove_qualifier(self):
         text = """

--- a/src/core/tests/test_v1_parser.py
+++ b/src/core/tests/test_v1_parser.py
@@ -17,14 +17,20 @@ class TestV1ParserCommand(TestCase):
         parser = V1CommandParser()
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("CREATE\tQ123\t")
-        self.assertEqual(context.exception.message, "CREATE command can have only 1 column")
+        self.assertEqual(
+            context.exception.message, "CREATE command can have only 1 column"
+        )
 
     def test_v1_correct_merge_command(self):
         parser = V1CommandParser()
         data = parser.parse_command("MERGE\tQ2\tQ1")
-        self.assertEqual(data, {"action": "merge", "type": "item", "item1": "Q1", "item2": "Q2"})
+        self.assertEqual(
+            data, {"action": "merge", "type": "item", "item1": "Q1", "item2": "Q2"}
+        )
         data = parser.parse_command("MERGE \tQ1 \tQ2 ")
-        self.assertEqual(data, {"action": "merge", "type": "item", "item1": "Q1", "item2": "Q2"})
+        self.assertEqual(
+            data, {"action": "merge", "type": "item", "item1": "Q1", "item2": "Q2"}
+        )
 
     def test_v1_bad_merge_command(self):
         parser = V1CommandParser()
@@ -61,28 +67,33 @@ class TestV1ParserCommand(TestCase):
             data = parser.parse_command(f"CREATE_PROPERTY\t{datatype}")
             self.assertEqual(
                 data,
-                {
-                    "action": "create",
-                    "type": "property",
-                    "data": datatype
-                },
+                {"action": "create", "type": "property", "data": datatype},
             )
 
     def test_v1_bad_create_property(self):
         parser = V1CommandParser()
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("CREATE_PROPERTY")
-        self.assertEqual(context.exception.message, "CREATE PROPERTY command must have 2 columns")
+        self.assertEqual(
+            context.exception.message, "CREATE PROPERTY command must have 2 columns"
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("CREATE_PROPERTY\tP1\t12")
-        self.assertEqual(context.exception.message, "CREATE PROPERTY command must have 2 columns")
+        self.assertEqual(
+            context.exception.message, "CREATE PROPERTY command must have 2 columns"
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("CREATE_PROPERTY\tmy_datatype")
-        self.assertEqual(context.exception.message, "CREATE PROPERTY datatype allowed values: ['commonsMedia', 'globe-coordinate', 'wikibase-item', 'wikibase-property', 'string', 'monolingualtext', 'external-id', 'quantity', 'time', 'url', 'math', 'geo-shape', 'musical-notation', 'tabular-data', 'wikibase-lexeme', 'wikibase-form', 'wikibase-sense']")        
+        self.assertEqual(
+            context.exception.message,
+            "CREATE PROPERTY datatype allowed values: ['commonsMedia', 'globe-coordinate', 'wikibase-item', 'wikibase-property', 'string', 'monolingualtext', 'external-id', 'quantity', 'time', 'url', 'math', 'geo-shape', 'musical-notation', 'tabular-data', 'wikibase-lexeme', 'wikibase-form', 'wikibase-sense']",
+        )
 
     def test_v1_remove_statement_by_id(self):
         parser = V1CommandParser()
-        data = parser.parse_command("-STATEMENT\tQ4115189$0d52b2b4-4fa4-3bfa-8eda-cfe87ea23c34")
+        data = parser.parse_command(
+            "-STATEMENT\tQ4115189$0d52b2b4-4fa4-3bfa-8eda-cfe87ea23c34"
+        )
         self.assertEqual(
             data,
             {
@@ -97,16 +108,28 @@ class TestV1ParserCommand(TestCase):
         parser = V1CommandParser()
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("-STATEMENT")
-        self.assertEqual(context.exception.message, "remove statement by ID command must have 2 columns")
+        self.assertEqual(
+            context.exception.message,
+            "remove statement by ID command must have 2 columns",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("-STATEMENT\tP1\t12")
-        self.assertEqual(context.exception.message, "remove statement by ID command must have 2 columns")
+        self.assertEqual(
+            context.exception.message,
+            "remove statement by ID command must have 2 columns",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("-STATEMENT\tQ1")
-        self.assertEqual(context.exception.message, "ITEM ID format in REMOVE STATEMENT must be Q1234$UUID")
+        self.assertEqual(
+            context.exception.message,
+            "ITEM ID format in REMOVE STATEMENT must be Q1234$UUID",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("STATEMENT|Q1234$abcdefg-huijk")
-        self.assertEqual(context.exception.message, "STATEMENT must contain at least entity, property and value")
+        self.assertEqual(
+            context.exception.message,
+            "STATEMENT must contain at least entity, property and value",
+        )
 
     def test_v1_remove_quantity(self):
         parser = V1CommandParser()
@@ -129,7 +152,10 @@ class TestV1ParserCommand(TestCase):
                 "action": "remove",
                 "entity": {"type": "item", "id": "Q1234"},
                 "property": "P3",
-                "value": {"type": "quantity", "value": {"amount": "+12", "unit": "11573"}},
+                "value": {
+                    "type": "quantity",
+                    "value": {"amount": "+12", "unit": "11573"},
+                },
                 "what": "statement",
             },
         )
@@ -143,7 +169,12 @@ class TestV1ParserCommand(TestCase):
                 "property": "P4",
                 "value": {
                     "type": "quantity",
-                    "value": {"amount": "+9", "upperBound": "+9.1", "lowerBound": "+8.9", "unit": "1"},
+                    "value": {
+                        "amount": "+9",
+                        "upperBound": "+9.1",
+                        "lowerBound": "+8.9",
+                        "unit": "1",
+                    },
                 },
                 "what": "statement",
             },
@@ -184,7 +215,10 @@ class TestV1ParserCommand(TestCase):
                 "action": "add",
                 "entity": {"type": "item", "id": "Q1234"},
                 "property": "P3",
-                "value": {"type": "quantity", "value": {"amount": "+12", "unit": "11573"}},
+                "value": {
+                    "type": "quantity",
+                    "value": {"amount": "+12", "unit": "11573"},
+                },
                 "what": "statement",
             },
         )
@@ -198,7 +232,12 @@ class TestV1ParserCommand(TestCase):
                 "property": "P4",
                 "value": {
                     "type": "quantity",
-                    "value": {"amount": "+9", "upperBound": "+9.1", "lowerBound": "+8.9", "unit": "1"},
+                    "value": {
+                        "amount": "+9",
+                        "upperBound": "+9.1",
+                        "lowerBound": "+8.9",
+                        "unit": "1",
+                    },
                 },
                 "what": "statement",
             },
@@ -243,7 +282,9 @@ class TestV1ParserCommand(TestCase):
         parser = V1CommandParser()
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("Q1234\tDpt\tsomevalue")
-        self.assertEqual(context.exception.message, "description must be a string instance")
+        self.assertEqual(
+            context.exception.message, "description must be a string instance"
+        )
 
     def test_v1_add_label(self):
         parser = V1CommandParser()
@@ -283,7 +324,9 @@ class TestV1ParserCommand(TestCase):
         parser = V1CommandParser()
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("Q1234\tSpt\tsomevalue")
-        self.assertEqual(context.exception.message, "sitelink must be a string instance")
+        self.assertEqual(
+            context.exception.message, "sitelink must be a string instance"
+        )
 
     def test_v1_add_somevalue_novalue(self):
         parser = V1CommandParser()
@@ -390,7 +433,9 @@ class TestV1ParserCommand(TestCase):
 
     def test_v1_add_item_with_references(self):
         parser = V1CommandParser()
-        data = parser.parse_command('Q1234\tP2\tQ1\tS1\t"source text"\tS2\t+1967-01-17T00:00:00Z/11')
+        data = parser.parse_command(
+            'Q1234\tP2\tQ1\tS1\t"source text"\tS2\t+1967-01-17T00:00:00Z/11'
+        )
         self.assertEqual(
             data,
             {
@@ -400,7 +445,10 @@ class TestV1ParserCommand(TestCase):
                 "value": {"type": "wikibase-entityid", "value": "Q1"},
                 "references": [
                     [
-                        {"property": "P1", "value": {"type": "string", "value": "source text"}},
+                        {
+                            "property": "P1",
+                            "value": {"type": "string", "value": "source text"},
+                        },
                         {
                             "property": "P2",
                             "value": {
@@ -411,7 +459,7 @@ class TestV1ParserCommand(TestCase):
                                     "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
                                 },
                             },
-                        }
+                        },
                     ]
                 ],
                 "what": "statement",
@@ -420,7 +468,9 @@ class TestV1ParserCommand(TestCase):
 
     def test_v1_add_item_with_references_multiple_blocks(self):
         parser = V1CommandParser()
-        data = parser.parse_command('Q1234\tP2\tQ1\tS1\t"source text"\t!S2\t+1967-01-17T00:00:00Z/11')
+        data = parser.parse_command(
+            'Q1234\tP2\tQ1\tS1\t"source text"\t!S2\t+1967-01-17T00:00:00Z/11'
+        )
         self.assertEqual(
             data,
             {
@@ -431,11 +481,8 @@ class TestV1ParserCommand(TestCase):
                 "references": [
                     [
                         {
-                            "property": "P1", 
-                            "value": {
-                                "type": "string", 
-                                "value": "source text"
-                            }
+                            "property": "P1",
+                            "value": {"type": "string", "value": "source text"},
                         },
                     ],
                     [
@@ -450,7 +497,7 @@ class TestV1ParserCommand(TestCase):
                                 },
                             },
                         }
-                    ]
+                    ],
                 ],
                 "what": "statement",
             },
@@ -458,7 +505,9 @@ class TestV1ParserCommand(TestCase):
 
     def test_v1_add_item_with_qualifiers(self):
         parser = V1CommandParser()
-        data = parser.parse_command('Q1234\tP2\tQ1\tP1\t"qualifier text"\tP2\t+1970-01-17T00:00:00Z/11')
+        data = parser.parse_command(
+            'Q1234\tP2\tQ1\tP1\t"qualifier text"\tP2\t+1970-01-17T00:00:00Z/11'
+        )
         self.assertEqual(
             data,
             {
@@ -467,7 +516,10 @@ class TestV1ParserCommand(TestCase):
                 "property": "P2",
                 "value": {"type": "wikibase-entityid", "value": "Q1"},
                 "qualifiers": [
-                    {"property": "P1", "value": {"type": "string", "value": "qualifier text"}},
+                    {
+                        "property": "P1",
+                        "value": {"type": "string", "value": "qualifier text"},
+                    },
                     {
                         "property": "P2",
                         "value": {
@@ -497,7 +549,10 @@ class TestV1ParserCommand(TestCase):
                 "property": "P2",
                 "value": {"type": "wikibase-entityid", "value": "Q1"},
                 "qualifiers": [
-                    {"property": "P1", "value": {"type": "string", "value": "qualifier text"}},
+                    {
+                        "property": "P1",
+                        "value": {"type": "string", "value": "qualifier text"},
+                    },
                     {
                         "property": "P2",
                         "value": {
@@ -512,7 +567,10 @@ class TestV1ParserCommand(TestCase):
                 ],
                 "references": [
                     [
-                        {"property": "P1", "value": {"type": "string", "value": "source text"}},
+                        {
+                            "property": "P1",
+                            "value": {"type": "string", "value": "source text"},
+                        },
                         {
                             "property": "P2",
                             "value": {
@@ -523,7 +581,7 @@ class TestV1ParserCommand(TestCase):
                                     "calendarmodel": "http://www.wikidata.org/entity/Q1985727",
                                 },
                             },
-                        }
+                        },
                     ]
                 ],
                 "what": "statement",
@@ -544,7 +602,14 @@ class TestV1ParserCommand(TestCase):
 
         data = parser.parse_command("MERGE\tQ1\tQ2 /* This is a comment. */")
         self.assertEqual(
-            data, {"action": "merge", "type": "item", "item1": "Q1", "item2": "Q2", "summary": "This is a comment."}
+            data,
+            {
+                "action": "merge",
+                "type": "item",
+                "item1": "Q1",
+                "item2": "Q2",
+                "summary": "This is a comment.",
+            },
         )
 
     def test_v1_statement_rank(self):
@@ -576,46 +641,86 @@ class TestV1ParserCommand(TestCase):
         parser = V1CommandParser()
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_QUAL")
-        self.assertEqual(context.exception.message, "REMOVE_QUAL command must be Qid|Pid|value|Pid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_QUAL command must be Qid|Pid|value|Pid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_QUAL\tQ1")
-        self.assertEqual(context.exception.message, "REMOVE_QUAL command must be Qid|Pid|value|Pid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_QUAL command must be Qid|Pid|value|Pid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_QUAL\tQ1\tP2")
-        self.assertEqual(context.exception.message, "REMOVE_QUAL command must be Qid|Pid|value|Pid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_QUAL command must be Qid|Pid|value|Pid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_QUAL\tQ1\tP2\tQ3")
-        self.assertEqual(context.exception.message, "REMOVE_QUAL command must be Qid|Pid|value|Pid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_QUAL command must be Qid|Pid|value|Pid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_QUAL\tQ1\tP2\tQ3\tP4")
-        self.assertEqual(context.exception.message, "REMOVE_QUAL command must be Qid|Pid|value|Pid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_QUAL command must be Qid|Pid|value|Pid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_QUAL\tQ1\tP2\tQ3\tP4\tQ5\tP6")
-        self.assertEqual(context.exception.message, "REMOVE_QUAL command must be Qid|Pid|value|Pid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_QUAL command must be Qid|Pid|value|Pid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_QUAL\tQ1\tP2\tQ3\tS4\tQ5")
-        self.assertEqual(context.exception.message, "REMOVE_QUAL command must have 1 qualifier")
+        self.assertEqual(
+            context.exception.message, "REMOVE_QUAL command must have 1 qualifier"
+        )
 
     def test_v1_bad_remove_reference(self):
         parser = V1CommandParser()
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_REF")
-        self.assertEqual(context.exception.message, "REMOVE_REF command must be Qid|Pid|value|Sid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_REF command must be Qid|Pid|value|Sid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_REF\tQ1")
-        self.assertEqual(context.exception.message, "REMOVE_REF command must be Qid|Pid|value|Sid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_REF command must be Qid|Pid|value|Sid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_REF\tQ1\tP2")
-        self.assertEqual(context.exception.message, "REMOVE_REF command must be Qid|Pid|value|Sid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_REF command must be Qid|Pid|value|Sid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_REF\tQ1\tP2\tQ3")
-        self.assertEqual(context.exception.message, "REMOVE_REF command must be Qid|Pid|value|Sid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_REF command must be Qid|Pid|value|Sid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_REF\tQ1\tP2\tQ3\tS4")
-        self.assertEqual(context.exception.message, "REMOVE_REF command must be Qid|Pid|value|Sid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_REF command must be Qid|Pid|value|Sid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_REF\tQ1\tP2\tQ3\tS4\tQ5\tS6")
-        self.assertEqual(context.exception.message, "REMOVE_REF command must be Qid|Pid|value|Sid|value")
+        self.assertEqual(
+            context.exception.message,
+            "REMOVE_REF command must be Qid|Pid|value|Sid|value",
+        )
         with self.assertRaises(Exception) as context:
             _data = parser.parse_command("REMOVE_REF\tQ1\tP2\tQ3\tP4\tQ5")
-        self.assertEqual(context.exception.message, "REMOVE_REF command must have 1 reference")
+        self.assertEqual(
+            context.exception.message, "REMOVE_REF command must have 1 reference"
+        )

--- a/src/manage.py
+++ b/src/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'qsts3.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "qsts3.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -18,5 +18,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/src/qsts3/asgi.py
+++ b/src/qsts3/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'qsts3.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "qsts3.settings")
 
 application = get_asgi_application()

--- a/src/qsts3/wsgi.py
+++ b/src/qsts3/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'qsts3.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "qsts3.settings")
 
 application = get_wsgi_application()

--- a/src/web/apps.py
+++ b/src/web/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class WebConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'web'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "web"

--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -7,7 +7,9 @@ from web.models import Preferences
 def language_cookie_middleware(get_response):
     def middleware(request):
         if request.user.is_authenticated:
-            language = Preferences.objects.get_language(request.user, settings.LANGUAGE_CODE)
+            language = Preferences.objects.get_language(
+                request.user, settings.LANGUAGE_CODE
+            )
         else:
             language = settings.LANGUAGE_CODE
 

--- a/src/web/migrations/0001_initial.py
+++ b/src/web/migrations/0001_initial.py
@@ -15,15 +15,29 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.CreateModel(
-            name='Token',
+            name="Token",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('value', models.TextField(blank=True, null=True)),
-                ('user', models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("value", models.TextField(blank=True, null=True)),
+                (
+                    "user",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
             ],
             options={
-                'verbose_name': 'Token',
-                'verbose_name_plural': 'Tokens',
+                "verbose_name": "Token",
+                "verbose_name_plural": "Tokens",
             },
         ),
     ]

--- a/src/web/migrations/0004_token_expires_at_token_refresh_token.py
+++ b/src/web/migrations/0004_token_expires_at_token_refresh_token.py
@@ -6,18 +6,18 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('web', '0003_alter_preferences_language'),
+        ("web", "0003_alter_preferences_language"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='token',
-            name='expires_at',
+            model_name="token",
+            name="expires_at",
             field=models.DateTimeField(blank=True, null=True),
         ),
         migrations.AddField(
-            model_name='token',
-            name='refresh_token',
+            model_name="token",
+            name="refresh_token",
             field=models.TextField(blank=True, null=True),
         ),
     ]

--- a/src/web/models.py
+++ b/src/web/models.py
@@ -89,7 +89,9 @@ class Preferences(models.Model):
     """
 
     user = models.OneToOneField(User, on_delete=models.CASCADE, blank=False, null=False)
-    language = models.CharField(max_length=32, choices=LANGUAGE_CHOICES, blank=True, null=False)
+    language = models.CharField(
+        max_length=32, choices=LANGUAGE_CHOICES, blank=True, null=False
+    )
 
     objects = PreferencesManager()
 

--- a/src/web/tests/test_auth.py
+++ b/src/web/tests/test_auth.py
@@ -251,4 +251,3 @@ class OAuthCallback(TestCase):
         self.assertStatus(res, 401)
         self.assertInRes("The authentication server is being", res)
         self.assertInRes("not supposed to be here right now.", res)
-

--- a/src/web/tests/test_profile.py
+++ b/src/web/tests/test_profile.py
@@ -55,7 +55,9 @@ class ProfileTest(TestCase):
         self.assertEqual(Token.objects.count(), 1)
 
         data = urlencode({"action": "update_language", "language": "fr"})
-        response = c.post("/auth/profile/", data, content_type="application/x-www-form-urlencoded")
+        response = c.post(
+            "/auth/profile/", data, content_type="application/x-www-form-urlencoded"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("profile.html")
 
@@ -75,12 +77,14 @@ class ProfileTest(TestCase):
         self.assertTemplateUsed("profile.html")
 
         self.assertEqual(response.context["language"], "en")
-        
+
         prev_token = Token.objects.get(user=user)
         self.assertEqual(response.context["token"], prev_token.key)
 
         data = urlencode({"action": "update_token"})
-        response = c.post("/auth/profile/", data, content_type="application/x-www-form-urlencoded")
+        response = c.post(
+            "/auth/profile/", data, content_type="application/x-www-form-urlencoded"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("profile.html")
 

--- a/src/web/tests/test_token.py
+++ b/src/web/tests/test_token.py
@@ -61,20 +61,20 @@ class TokenTests(TestCase):
             now() + timedelta(minutes=2),
             now() + timedelta(minutes=4),
             now() + timedelta(minutes=4, seconds=59),
-       ):
-           token.expires_at = value
-           token.save()
-           self.assertTrue(token.is_expired())
+        ):
+            token.expires_at = value
+            token.save()
+            self.assertTrue(token.is_expired())
 
         for value in (
             now() + timedelta(minutes=5, seconds=10),
             now() + timedelta(minutes=6),
             now() + timedelta(hours=3),
             None,
-       ):
-           token.expires_at = value
-           token.save()
-           self.assertFalse(token.is_expired())
+        ):
+            token.expires_at = value
+            token.save()
+            self.assertFalse(token.is_expired())
 
     def test_str(self):
         user = User.objects.create(username="u1")
@@ -82,5 +82,3 @@ class TokenTests(TestCase):
         self.assertEqual(str(token), f"Token for {user}: [redacted]")
         token = Token(value="x")
         self.assertEqual(str(token), "Anonymous token: [redacted]")
-        
-

--- a/src/web/tests/test_views.py
+++ b/src/web/tests/test_views.py
@@ -137,16 +137,36 @@ class ViewsTest(TestCase):
     def test_batch_command_filters(self):
         batch = Batch.objects.create(name="My new batch", user="mgalves80")
         b1 = BatchCommand.objects.create(
-            batch=batch, index=0, action=BatchCommand.ACTION_ADD, json={}, raw="{}", status=BatchCommand.STATUS_INITIAL
+            batch=batch,
+            index=0,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            raw="{}",
+            status=BatchCommand.STATUS_INITIAL,
         )
         b2 = BatchCommand.objects.create(
-            batch=batch, index=1, action=BatchCommand.ACTION_ADD, json={}, raw="{}", status=BatchCommand.STATUS_ERROR
+            batch=batch,
+            index=1,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            raw="{}",
+            status=BatchCommand.STATUS_ERROR,
         )
         b3 = BatchCommand.objects.create(
-            batch=batch, index=2, action=BatchCommand.ACTION_ADD, json={}, raw="{}", status=BatchCommand.STATUS_INITIAL
+            batch=batch,
+            index=2,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            raw="{}",
+            status=BatchCommand.STATUS_INITIAL,
         )
         b4 = BatchCommand.objects.create(
-            batch=batch, index=4, action=BatchCommand.ACTION_ADD, json={}, raw="{}", status=BatchCommand.STATUS_ERROR
+            batch=batch,
+            index=4,
+            action=BatchCommand.ACTION_ADD,
+            json={},
+            raw="{}",
+            status=BatchCommand.STATUS_ERROR,
         )
 
         c = Client()
@@ -204,7 +224,12 @@ class ViewsTest(TestCase):
         self.assertTemplateUsed("new_batch.html")
 
         response = self.client.post(
-            "/batch/new/", data={"name": "My v1 batch", "type": "v1", "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1"}
+            "/batch/new/",
+            data={
+                "name": "My v1 batch",
+                "type": "v1",
+                "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1",
+            },
         )
         self.assertEqual(response.status_code, 302)
 
@@ -233,7 +258,9 @@ class ViewsTest(TestCase):
     def test_create_empty_name(self, mocker):
         ApiMocker.is_autoconfirmed(mocker)
         user, api_client = self.login_user_and_get_token("user")
-        response = self.client.post("/batch/new/", data={"type": "v1", "commands": "CREATE"})
+        response = self.client.post(
+            "/batch/new/", data={"type": "v1", "commands": "CREATE"}
+        )
         self.assertEqual(response.status_code, 302)
         response = self.client.get(response.url)
         self.assertEqual(response.status_code, 200)
@@ -259,7 +286,8 @@ class ViewsTest(TestCase):
         self.assertTemplateUsed("new_batch.html")
 
         response = self.client.post(
-            "/batch/new/", data={"name": "My CSV batch", "type": "csv", "commands": "qid,P31,-P31"}
+            "/batch/new/",
+            data={"name": "My CSV batch", "type": "csv", "commands": "qid,P31,-P31"},
         )
         self.assertEqual(response.status_code, 302)
 
@@ -292,7 +320,12 @@ class ViewsTest(TestCase):
         self.assertEqual(response.headers["Location"], "/auth/login/?next=/batch/new/")
 
         response = c.post(
-            "/batch/new/", data={"name": "My v1 batch", "type": "v1", "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1"}
+            "/batch/new/",
+            data={
+                "name": "My v1 batch",
+                "type": "v1",
+                "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1",
+            },
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.headers["Location"], "/auth/login/?next=/batch/new/")
@@ -305,10 +338,12 @@ class ViewsTest(TestCase):
         batch = parser.parse("Batch", "wikiuser", "Q1234\tP2\tQ1")
         batch.save_batch_and_preview_commands()
 
-        labels = {"Q1234": {
-            "en": "English label",
-            "pt": "Portuguese label",
-        }}
+        labels = {
+            "Q1234": {
+                "en": "English label",
+                "pt": "Portuguese label",
+            }
+        }
         ApiMocker.labels(mocker, api_client, labels)
 
         response = self.client.get(f"/batch/{batch.pk}/commands/")
@@ -341,7 +376,9 @@ class ViewsTest(TestCase):
         self.assertTemplateUsed("profile.html")
         self.assertEqual(res.context["is_autoconfirmed"], True)
         self.assertEqual(res.context["token_failed"], False)
-        self.assertInRes("We have successfully verified that you are an autoconfirmed user.", res)
+        self.assertInRes(
+            "We have successfully verified that you are an autoconfirmed user.", res
+        )
 
     @requests_mock.Mocker()
     def test_profile_is_not_autoconfirmed(self, mocker):
@@ -400,7 +437,12 @@ class ViewsTest(TestCase):
         user, api_client = self.login_user_and_get_token("user")
 
         response = self.client.post(
-            "/batch/new/", data={"name": "My v1 batch", "type": "v1", "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1"}
+            "/batch/new/",
+            data={
+                "name": "My v1 batch",
+                "type": "v1",
+                "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1",
+            },
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.url, "/batch/new/preview/")
@@ -424,33 +466,46 @@ class ViewsTest(TestCase):
         ApiMocker.is_not_autoconfirmed(mocker)
         user, api_client = self.login_user_and_get_token("user")
 
-        res = self.client.post("/batch/new/", data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"})
+        res = self.client.post(
+            "/batch/new/",
+            data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"},
+        )
         self.assertEqual(res.status_code, 302)
         res = self.client.get(res.url)
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.context["is_autoconfirmed"], False)
         self.assertInRes("only autoconfirmed users can run batches", res)
-        self.assertInRes("""<input type="submit" value="Save and run batch" disabled>""", res)
+        self.assertInRes(
+            """<input type="submit" value="Save and run batch" disabled>""", res
+        )
 
     @requests_mock.Mocker()
     def test_allow_start_after_create_is_autoconfirmed(self, mocker):
         ApiMocker.is_autoconfirmed(mocker)
         user, api_client = self.login_user_and_get_token("user")
 
-        res = self.client.post("/batch/new/", data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"})
+        res = self.client.post(
+            "/batch/new/",
+            data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"},
+        )
         self.assertEqual(res.status_code, 302)
         res = self.client.get(res.url)
         self.assertEqual(res.status_code, 200)
         self.assertEqual(res.context["is_autoconfirmed"], True)
         self.assertInRes("""<input type="submit" value="Save and run batch">""", res)
         self.assertNotInRes("only autoconfirmed users can run batches", res)
-        self.assertNotInRes("""<input type="submit" value="Save and run batch" disabled>""", res)
+        self.assertNotInRes(
+            """<input type="submit" value="Save and run batch" disabled>""", res
+        )
 
     @requests_mock.Mocker()
     def test_allow_start_after_create_token_expired(self, mocker):
         ApiMocker.autoconfirmed_failed_unauthorized(mocker)
         user, api_client = self.login_user_and_get_token("user")
-        res = self.client.post("/batch/new/", data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"})
+        res = self.client.post(
+            "/batch/new/",
+            data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"},
+        )
         self.assertEqual(res.status_code, 302)
         res = self.client.get(res.url)
         self.assertRedirectToUrlName(res, "login")
@@ -462,7 +517,10 @@ class ViewsTest(TestCase):
         ApiMocker.is_autoconfirmed(mocker)
         user, api_client = self.login_user_and_get_token("user")
 
-        res = self.client.post("/batch/new/", data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"})
+        res = self.client.post(
+            "/batch/new/",
+            data={"name": "name", "type": "v1", "commands": "CREATE||LAST|P1|Q1"},
+        )
         self.assertEqual(res.status_code, 302)
         url = res.url
         res = self.client.get(url)
@@ -536,7 +594,12 @@ class ViewsTest(TestCase):
         user, api_client = self.login_user_and_get_token("user")
 
         response = self.client.post(
-            "/batch/new/", data={"name": "My v1 batch", "type": "v1", "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1"}
+            "/batch/new/",
+            data={
+                "name": "My v1 batch",
+                "type": "v1",
+                "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1",
+            },
         )
         self.assertEqual(response.status_code, 302)
 
@@ -569,7 +632,12 @@ class ViewsTest(TestCase):
         ApiMocker.labels(mocker, api_client, labels)
         ApiMocker.labels(mocker, api_client, labels)
         res = self.client.post(
-            "/batch/new/", data={"name": "My v1 batch", "type": "v1", "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1"}
+            "/batch/new/",
+            data={
+                "name": "My v1 batch",
+                "type": "v1",
+                "commands": "CREATE||-Q1234|P1|12||Q222|P4|9~0.1",
+            },
         )
         self.assertEqual(res.status_code, 302)
         res = self.client.get(res.url)
@@ -586,7 +654,9 @@ class ViewsTest(TestCase):
         ApiMocker.item_empty(mocker, "Q1234")
         ApiMocker.item_empty(mocker, "Q11")
         ApiMocker.patch_item_successful(mocker, "Q1234", {"id": "Q1234$stuff"})
-        ApiMocker.patch_item_successful(mocker, "Q11", {"id": "Q11", "labels": {"en": "label"}})
+        ApiMocker.patch_item_successful(
+            mocker, "Q11", {"id": "Q11", "labels": {"en": "label"}}
+        )
         user, api_client = self.login_user_and_get_token("wikiuser")
         parser = V1CommandParser()
         batch = parser.parse("Batch", "wikiuser", """Q1234\tP2\tQ1||Q11|Len|"label" """)
@@ -596,15 +666,21 @@ class ViewsTest(TestCase):
         response = self.client.get(f"/batch/{pk}/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("batch.html")
-        self.assertNotInRes(f"""<form method="GET" action="/batch/{pk}/report/">""", response)
-        self.assertNotInRes("""<input type="submit" value="Download report">""", response)
+        self.assertNotInRes(
+            f"""<form method="GET" action="/batch/{pk}/report/">""", response
+        )
+        self.assertNotInRes(
+            """<input type="submit" value="Download report">""", response
+        )
 
         batch.run()
 
         response = self.client.get(f"/batch/{pk}/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("batch.html")
-        self.assertInRes(f"""<form method="GET" action="/batch/{pk}/report/">""", response)
+        self.assertInRes(
+            f"""<form method="GET" action="/batch/{pk}/report/">""", response
+        )
         self.assertInRes("""<input type="submit" value="Download report">""", response)
 
         response = self.client.post(f"/batch/{pk}/report/")
@@ -612,7 +688,10 @@ class ViewsTest(TestCase):
 
         response = self.client.get(f"/batch/{pk}/report/")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.headers["Content-Disposition"], f'attachment; filename="batch-{pk}-report.csv"')
+        self.assertEqual(
+            response.headers["Content-Disposition"],
+            f'attachment; filename="batch-{pk}-report.csv"',
+        )
         result = (
             """b'batch_id,index,operation,status,error,message,entity_id,raw_input\\r\\n"""
             f"""{pk},0,set_statement,Done,,,Q1234,Q1234|P2|Q1\\r\\n"""
@@ -630,13 +709,16 @@ class ViewsTest(TestCase):
         _user, api_client = self.login_user_and_get_token("wikiuser")
         response = self.client.post(
             "/batch/new/",
-            data={"type": "v1", "commands": """
+            data={
+                "type": "v1",
+                "commands": """
             Q1|P2|Q2
             Q1|P2|"string"
             Q1|P2|32
             Q1|P2|Q2
             Q1|P2|32
-            """}
+            """,
+            },
         )
         response = self.client.get("/batch/new/preview/")
         self.assertEqual(response.status_code, 200)
@@ -746,12 +828,22 @@ class ViewsTest(TestCase):
         response = self.client.get(f"/batch/{pk}/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("batch.html")
-        self.assertInRes("""<a href="https://www.wikidata.org/wiki/User:wikiuser">wikiuser</a>""", response)
+        self.assertInRes(
+            """<a href="https://www.wikidata.org/wiki/User:wikiuser">wikiuser</a>""",
+            response,
+        )
         self.assertInRes("""[<a href="/batches/wikiuser/">""", response)
-        self.assertInRes(f"""<a href="https://editgroups.toolforge.org/b/QSv3/{pk}">""", response)
+        self.assertInRes(
+            f"""<a href="https://editgroups.toolforge.org/b/QSv3/{pk}">""", response
+        )
         batch.run()
         response = self.client.get(f"/batch/{pk}/")
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed("batch.html")
-        self.assertInRes("""<a href="https://www.wikidata.org/wiki/User:wikiuser">wikiuser</a>""", response)
-        self.assertInRes(f"""<a href="https://editgroups.toolforge.org/b/QSv3/{pk}">""", response)
+        self.assertInRes(
+            """<a href="https://www.wikidata.org/wiki/User:wikiuser">wikiuser</a>""",
+            response,
+        )
+        self.assertInRes(
+            f"""<a href="https://editgroups.toolforge.org/b/QSv3/{pk}">""", response
+        )

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -40,6 +40,10 @@ urlpatterns = [
     path("batch/<int:pk>/commands/", batch_commands, name="batch_commands"),
     path("batch/new/", new_batch, name="new_batch"),
     path("batch/new/preview/", preview_batch, name="preview_batch"),
-    path("batch/new/preview/commands/", preview_batch_commands, name="preview_batch_commands"),
+    path(
+        "batch/new/preview/commands/",
+        preview_batch_commands,
+        name="preview_batch_commands",
+    ),
     path("batch/new/preview/allow_start/", batch_allow_start, name="batch_allow_start"),
 ]

--- a/src/web/views/batch.py
+++ b/src/web/views/batch.py
@@ -33,12 +33,18 @@ def batch(request, pk):
     """
     try:
         batch = Batch.objects.get(pk=pk)
-        current_owner = request.user.is_authenticated and request.user.username == batch.user
+        current_owner = (
+            request.user.is_authenticated and request.user.username == batch.user
+        )
         is_autoconfirmed = None
         return render(
             request,
             "batch.html",
-            {"batch": batch, "current_owner": current_owner, "is_autoconfirmed": is_autoconfirmed},
+            {
+                "batch": batch,
+                "current_owner": current_owner,
+                "is_autoconfirmed": is_autoconfirmed,
+            },
         )
     except Batch.DoesNotExist:
         return render(request, "batch_not_found.html", {"pk": pk}, status=404)
@@ -56,7 +62,9 @@ def batch_stop(request, pk):
     """
     try:
         batch = Batch.objects.get(pk=pk)
-        current_owner = request.user.is_authenticated and request.user.username == batch.user
+        current_owner = (
+            request.user.is_authenticated and request.user.username == batch.user
+        )
         if current_owner:
             batch.stop()
         return redirect(reverse("batch", args=[batch.pk]))
@@ -76,22 +84,29 @@ def batch_restart(request, pk):
     """
     try:
         batch = Batch.objects.get(pk=pk)
-        current_owner = request.user.is_authenticated and request.user.username == batch.user
+        current_owner = (
+            request.user.is_authenticated and request.user.username == batch.user
+        )
         if current_owner:
             batch.restart()
         return redirect(reverse("batch", args=[batch.pk]))
     except Batch.DoesNotExist:
         return render(request, "batch_not_found.html", {"pk": pk}, status=404)
 
+
 @require_GET
 def batch_report(request, pk):
     try:
         batch = Batch.objects.get(pk=pk)
-        current_owner = request.user.is_authenticated and request.user.username == batch.user
+        current_owner = (
+            request.user.is_authenticated and request.user.username == batch.user
+        )
         if current_owner and batch.is_done:
             res = HttpResponse(
                 content_type="text/csv",
-                headers={"Content-Disposition": f'attachment; filename="batch-{pk}-report.csv"'},
+                headers={
+                    "Content-Disposition": f'attachment; filename="batch-{pk}-report.csv"'
+                },
             )
             batch.write_report(res)
             return res
@@ -122,7 +137,9 @@ def batch_commands(request, pk):
     if only_errors:
         filters["status"] = BatchCommand.STATUS_ERROR
 
-    paginator = Paginator(BatchCommand.objects.filter(**filters).order_by("index"), PAGE_SIZE)
+    paginator = Paginator(
+        BatchCommand.objects.filter(**filters).order_by("index"), PAGE_SIZE
+    )
     page = paginator.page(page)
 
     if request.user.is_authenticated:
@@ -138,7 +155,16 @@ def batch_commands(request, pk):
             pass
 
     base_url = reverse("batch_commands", args=[pk])
-    return render(request, "batch_commands.html", {"page": page, "batch_pk": pk, "only_errors": only_errors, "base_url": base_url})
+    return render(
+        request,
+        "batch_commands.html",
+        {
+            "page": page,
+            "batch_pk": pk,
+            "only_errors": only_errors,
+            "base_url": base_url,
+        },
+    )
 
 
 @require_http_methods(
@@ -159,10 +185,18 @@ def batch_summary(request, pk):
     try:
         from django.db.models import Q, Count
 
-        error_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_ERROR))
-        initial_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_INITIAL))
-        running_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_RUNNING))
-        done_commands = Count("batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_DONE))
+        error_commands = Count(
+            "batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_ERROR)
+        )
+        initial_commands = Count(
+            "batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_INITIAL)
+        )
+        running_commands = Count(
+            "batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_RUNNING)
+        )
+        done_commands = Count(
+            "batchcommand", filter=Q(batchcommand__status=BatchCommand.STATUS_DONE)
+        )
         batch = (
             Batch.objects.annotate(error_commands=error_commands)
             .annotate(initial_commands=initial_commands)
@@ -171,7 +205,9 @@ def batch_summary(request, pk):
             .annotate(total_commands=Count("batchcommand"))
             .get(pk=pk)
         )
-        show_block_on_errors_notice = batch.is_preview_initial_or_running and batch.block_on_errors
+        show_block_on_errors_notice = (
+            batch.is_preview_initial_or_running and batch.block_on_errors
+        )
         finished_commands = batch.done_commands + batch.error_commands
 
         def percentage(val, max):
@@ -189,9 +225,15 @@ def batch_summary(request, pk):
                 "running_count": batch.running_commands,
                 "done_count": batch.done_commands,
                 "total_count": batch.total_commands,
-                "done_percentage": percentage(batch.done_commands, batch.total_commands),
-                "finish_percentage": percentage(finished_commands, batch.total_commands),
-                "done_to_finish_percentage": percentage(batch.done_commands, finished_commands),
+                "done_percentage": percentage(
+                    batch.done_commands, batch.total_commands
+                ),
+                "finish_percentage": percentage(
+                    finished_commands, batch.total_commands
+                ),
+                "done_to_finish_percentage": percentage(
+                    batch.done_commands, finished_commands
+                ),
                 "show_block_on_errors_notice": show_block_on_errors_notice,
             },
         )

--- a/src/web/views/batches.py
+++ b/src/web/views/batches.py
@@ -36,7 +36,9 @@ def last_batches(request):
         page = 1
     paginator = Paginator(Batch.objects.all().order_by("-modified"), PAGE_SIZE)
     base_url = reverse("last_batches")
-    return render(request, "batches.html", {"page": paginator.page(page), "base_url": base_url})
+    return render(
+        request, "batches.html", {"page": paginator.page(page), "base_url": base_url}
+    )
 
 
 @require_http_methods(
@@ -52,7 +54,9 @@ def last_batches_by_user(request, user):
         page = int(request.GET.get("page", 1))
     except (TypeError, ValueError):
         page = 1
-    paginator = Paginator(Batch.objects.filter(user=user).order_by("-modified"), PAGE_SIZE)
+    paginator = Paginator(
+        Batch.objects.filter(user=user).order_by("-modified"), PAGE_SIZE
+    )
     base_url = reverse("last_batches_by_user", args=[user])
     # we need to use `username` since `user` is always supplied by django templates
     return render(

--- a/src/web/views/new_batch.py
+++ b/src/web/views/new_batch.py
@@ -99,23 +99,26 @@ def preview_batch_commands(request):
         only_errors = int(request.GET.get("show_errors", 0)) == 1
         if only_errors:
             batch_commands = [
-                bc for bc in batch_commands if bc.object.status == BatchCommand.STATUS_ERROR
+                bc
+                for bc in batch_commands
+                if bc.object.status == BatchCommand.STATUS_ERROR
             ]
 
         paginator = Paginator(batch_commands, PAGE_SIZE)
         page = paginator.page(page)
-        page.object_list = [
-            d.object for d in page.object_list
-        ]
+        page.object_list = [d.object for d in page.object_list]
 
         if request.user.is_authenticated:
             client = Client.from_user(request.user)
             language = Preferences.objects.get_language(request.user, "en")
             BatchCommand.load_labels(client, page.object_list, language)
 
-
     base_url = reverse("preview_batch_commands")
-    return render(request, "batch_commands.html", {"page": page, "only_errors": only_errors, "base_url": base_url})
+    return render(
+        request,
+        "batch_commands.html",
+        {"page": page, "only_errors": only_errors, "base_url": base_url},
+    )
 
 
 @login_required()
@@ -127,7 +130,9 @@ def new_batch(request):
         try:
             batch_owner = request.user.username
             batch_commands = request.POST.get("commands")
-            batch_name = request.POST.get("name", f"Batch  user:{batch_owner} {datetime.now().isoformat()}")
+            batch_name = request.POST.get(
+                "name", f"Batch  user:{batch_owner} {datetime.now().isoformat()}"
+            )
             batch_type = request.POST.get("type", "v1")
             request.session["preferred_batch_type"] = batch_type
 
@@ -149,7 +154,9 @@ def new_batch(request):
             batch.combine_commands = "do_not_combine_commands" not in request.POST
 
             serialized_batch = serializers.serialize("json", [batch])
-            serialized_commands = serializers.serialize("json", batch.get_preview_commands())
+            serialized_commands = serializers.serialize(
+                "json", batch.get_preview_commands()
+            )
 
             request.session["preview_batch"] = serialized_batch
             request.session["preview_commands"] = serialized_commands
@@ -211,7 +218,9 @@ def batch_allow_start(request):
             "new_batch.html",
             {
                 "is_autoconfirmed": is_autoconfirmed,
-                "error": _("User is not autoconfirmed. Only autoconfirmed users can run batches."),
+                "error": _(
+                    "User is not autoconfirmed. Only autoconfirmed users can run batches."
+                ),
             },
         )
 
@@ -222,7 +231,9 @@ def batch_allow_start(request):
             batch = list(serializers.deserialize("json", preview_batch))[0].object
 
             preview_batch_commands = request.session.get("preview_commands", "[]")
-            for batch_command in serializers.deserialize("json", preview_batch_commands):
+            for batch_command in serializers.deserialize(
+                "json", preview_batch_commands
+            ):
                 batch.add_preview_command(batch_command.object)
             batch.save_batch_and_preview_commands()
 


### PR DESCRIPTION
Passed all python files through "black" to lint the code and ensure that future PRs are not polluted with formatting changes.