### PR TITLE
Add stdin to allow attaching to debugger in container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ x-application-service: &application-service
     mariadb:
       condition: service_healthy
   restart: unless-stopped
+  stdin_open: true
+  tty: true
   environment: &application-environment
     DJANGO_SETTINGS_MODULE: qsts3.settings
     DB_NAME: quickstatements


### PR DESCRIPTION
If we don't do this, it will throw an exception when trying to open a python debugger in the django process.