### PR TITLE
Refactor of the deployment script in order to fix production CD

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,29 +4,37 @@ set -eu
 
 PROJECT_DIR="${HOME}/www/python"
 SRC_DIR="${PROJECT_DIR}/src"
+POD="$(kubectl get pods -n tool-qs-dev -o name| head -n1 | cut -d/ -f2)"
 
-cd "${PROJECT_DIR}" || exit
+cd "${PROJECT_DIR}" || exit 1
 
 echo "==> Updating git repository..."
 git pull
 
 echo "==> Entering python shell..."
-toolforge webservice --backend=kubernetes python3.11 shell -- \
-  echo "==> Installing dependencies..." && \
-  export MYSQLCLIENT_CFLAGS="-I/usr/include/mariadb/" && \
-  export MYSQLCLIENT_LDFLAGS="-L/usr/lib/x86_64-linux-gnu/ -lmariadb" && \
+kubectl exec "${POD}" -- bash -euc \
+"
+  echo '==> Installing dependencies...' && \
+  export MYSQLCLIENT_CFLAGS='-I/usr/include/mariadb/' && \
+  export MYSQLCLIENT_LDFLAGS='-L/usr/lib/x86_64-linux-gnu/ -lmariadb' && \
   webservice-python-bootstrap && \
-  source "${PROJECT_DIR}/venv/bin/activate" && \
-  echo "==> Running migrations..." && \
-  python3 "${SRC_DIR}/manage.py" migrate && \
-  echo "==> Collecting static files..." && \
-  python3 "${SRC_DIR}/manage.py" collectstatic --noinput
+  source \"${PROJECT_DIR}/venv/bin/activate\" && \
+  echo '==> Running migrations...' && \
+  python3 \"${SRC_DIR}/manage.py\" migrate && \
+  echo '==> Collecting static files...' && \
+  python3 \"${SRC_DIR}/manage.py\" collectstatic --noinput
+"
 
-echo "==> Restarting webservice..."
-toolforge webservice --backend=kubernetes --mem 6Gi python3.11 restart
+echo '==> Restarting webservice...'
+toolforge webservice --backend=kubernetes --mem 4Gi python3.11 restart
 
-echo "==> Restarting batches..."
-toolforge webservice --backend=kubernetes python3.11 shell -- \
-  webservice-python-bootstrap  && \
-  source "${PROJECT_DIR}/venv/bin/activate" && \
-  python3 "${SRC_DIR}/manage.py" restart_batches
+echo '==> Pausing briefly to allow the container to start...'
+sleep 10
+
+POD="$(kubectl get pods -n tool-qs-dev -o name| head -n1 | cut -d/ -f2)"
+echo '==> Restarting batches...'
+kubectl exec "${POD}" -- bash -euc \
+"
+  source \"${PROJECT_DIR}/venv/bin/activate\" && \
+  python3 \"${SRC_DIR}/manage.py\" restart_batches
+"


### PR DESCRIPTION
The primary issue with the current implementation is that the `toolforge webservice shell` parser does not support multiple commands nor can it handle script/command parameters. Additionally, executing the command multiple times results in each command being run in a separate container, which leads to unnecessary resource allocation and increased execution time.

By running commands directly within our main webservice container, we can leverage the existing infrastructure, and utilizing `kubectl exec` allows us to execute multiple commands in a single request.